### PR TITLE
docs: update api endpoint docs 2026-04-14

### DIFF
--- a/api-reference/endpoints/get-intent-history.mdx
+++ b/api-reference/endpoints/get-intent-history.mdx
@@ -20,7 +20,7 @@ The `GetIntentHistory` endpoint provides a paginated view of intent history with
 All parameters are optional:
 
 - **page** (Page): Pagination configuration
-  - **column** (string): Column to paginate by (typically "id" or "createdAt")
+  - **column** (string): Column to paginate by (typically `"id"` or `"createdAt"`)
   - **before** (number): Cursor for previous page
   - **after** (number): Cursor for next page
   - **sort** (SortBy[]): Sorting configuration
@@ -30,6 +30,14 @@ All parameters are optional:
   - **more** (boolean): Indicates if more pages are available
 - **byProjectId** (number): Filter by project ID
 - **byOwnerAddress** (string): Filter by wallet address
+- **byStatus** (IntentStatus): Filter to a single status
+- **byStatuses** (IntentStatus[]): Filter to multiple statuses (takes precedence over `byStatus`)
+- **originChainId** (number): Filter by origin (source) chain ID
+- **destinationChainId** (number): Filter by destination chain ID
+- **fromTime** (number): Unix timestamp — return only intents created at or after this time
+- **toTime** (number): Unix timestamp — return only intents created at or before this time
+- **includeBalances** (boolean): When `true`, augment each history entry with on-chain balance data for the intent-relevant tokens
+- **onlyRecoverable** (boolean): When `true`, return only intents that have recoverable (stuck) balances
 
 ## Response
 
@@ -43,7 +51,7 @@ The response includes:
 Each `IntentHistory` object contains:
 
 - **intentId** (string): Unique intent identifier
-- **status** (IntentStatus): Current status (`QUOTED`, `COMMITTED`, `EXECUTING`, `FAILED`, `SUCCEEDED`, `ABORTED`, `REFUNDED`)
+- **status** (IntentStatus): Current status (`QUOTED`, `COMMITTED`, `EXECUTING`, `FAILED`, `SUCCEEDED`, `ABORTED`, `REFUNDED`, `INVALID`)
 - **expiresAt** (string): Intent expiration timestamp
 - **updatedAt** (string): Last update timestamp
 - **createdAt** (string): Creation timestamp

--- a/api-reference/endpoints/quote-intent.mdx
+++ b/api-reference/endpoints/quote-intent.mdx
@@ -30,13 +30,21 @@ The `QuoteIntent` endpoint allows you to request a quote for a cross-chain inten
 - **tradeType** (TradeType): Either `EXACT_INPUT` or `EXACT_OUTPUT`
 - **destinationTokenAmount** (bigint): Amount of destination tokens (only for EXACT_OUTPUT)
 - **originTokenAmount** (bigint): Amount of origin tokens (only for EXACT_INPUT)
+- **destinationToAddress** (string): Recipient address on the destination chain (defaults to `ownerAddress`)
+- **destinationApproveAddress** (string): Contract address to pre-approve on the destination chain before executing `destinationCallData`
 - **destinationCallData** (string): Custom calldata for contract interactions on destination chain
-- **destinationCallValue** (string): Value to send with the destination call
+- **destinationCallValue** (number): Value (in wei) to send with the destination call
+- **fundMethod** (FundMethod): Hint for the funding method — `WALLET`, `DIRECT_TRANSFER`, `ONRAMP_MESH`, or `ONRAMP_MELD`
+- **onlyNativeGasFee** (boolean): When `true`, restricts gas fee options to the origin chain's native token only
 - **options** (QuoteIntentRequestOptions):
-  - **bridgeProvider** (RouteProvider): Preferred bridge provider (`NONE`, `RELAY`, `CCTP`, `SUSHI`, `ZEROX`)
-  - **swapProvider** (RouteProvider): Preferred swap provider, only for for same chain swaps (`NONE`, `RELAY`, `CCTP`, `SUSHI`, `ZEROX`)
-  - **slippageTolerance** (number): Maximum acceptable slippage percentage as a fraction of 1 (e.g. 0.005 for 0.5%)
-  - **trailsAddressOverrides** (TrailsAddressOverrides): Custom Sequence wallet addresses
+  - **bridgeProvider** (RouteProvider): Preferred bridge provider — `AUTO` (default), `RELAY`, `CCTP`, `LZ_OFT`, `SUSHI`, `ZEROX`, `LIFI`, `WETH`
+  - **bridgeProviderFallback** (boolean): If `true`, fall back to another provider if the preferred bridge provider is unavailable
+  - **swapProvider** (RouteProvider): Preferred same-chain swap provider — `AUTO` (default), `RELAY`, `SUSHI`, `ZEROX`
+  - **swapProviderFallback** (boolean): If `true`, fall back to another provider if the preferred swap provider is unavailable
+  - **preference** (RoutePreference): Route optimisation target — `RECOMMENDED` (default), `FASTEST`, `CHEAPEST`, `TRUSTLESS`
+  - **intentProtocol** (IntentProtocolVersion): Force a specific intent protocol version — `v1` or `v1_5`
+  - **slippageTolerance** (number): Maximum acceptable slippage as a fraction of 1 (e.g. `0.005` for 0.5%)
+  - **trailsAddressOverrides** (TrailsAddressOverrides): Custom Sequence wallet addresses for the intent
 
 ## Response
 


### PR DESCRIPTION
## What changed

### `api-reference/endpoints/quote-intent.mdx`

**New optional request fields:**
- `destinationApproveAddress` — contract to pre-approve on destination before calldata executes (source: trails-api#584)
- `fundMethod` — hint for funding mode (`WALLET`, `DIRECT_TRANSFER`, `ONRAMP_MESH`, `ONRAMP_MELD`)
- `onlyNativeGasFee` — restrict gas fee options to native token only

**Updated `options` fields:**
- `bridgeProvider` / `swapProvider` values updated from `{NONE, RELAY, CCTP, SUSHI, ZEROX}` to the current `RouteProvider` enum: `AUTO`, `RELAY`, `CCTP`, `LZ_OFT`, `SUSHI`, `ZEROX`, `LIFI`, `WETH`
- New `bridgeProviderFallback` and `swapProviderFallback` booleans (source: trails-api release spec)
- New `preference` (`RoutePreference`: RECOMMENDED / FASTEST / CHEAPEST / TRUSTLESS)
- New `intentProtocol` (`v1` or `v1_5`)

### `api-reference/endpoints/get-intent-history.mdx`

**New filter parameters** (all optional):
- `byStatus` / `byStatuses` — single or multi-status filter (source: trails-api#515, #534)
- `originChainId` / `destinationChainId` — chain filters (source: trails-api#485)
- `fromTime` / `toTime` — Unix timestamp range (source: trails-api#485)
- `includeBalances` — augment with on-chain balance data (source: trails-api#530)
- `onlyRecoverable` — return only intents with recoverable balances (source: trails-api#544)

**Updated `IntentStatus` values:**
- Added `INVALID` (introduced in trails-api#454)

## Source of truth

All changes verified against `0xsequence/trails-api` `release` branch `proto/docs/trails-api.gen.yaml` (commit `512752fe`).

## Verification

- Check `QuoteIntent` endpoint playground in docs and confirm `bridgeProvider` enum shows updated values after PR #72 (spec sync) is also merged
- Confirm `GetIntentHistory` filter params match what the API accepts

Generated by the Trails Docs weekly agent.