### PR TITLE
docs: add endpoint pages and update mode docs 2026-04-14

### DIFF
--- a/api-reference/endpoints/abort-intent.mdx
+++ b/api-reference/endpoints/abort-intent.mdx
@@ -1,0 +1,81 @@
+---
+title: AbortIntent
+openapi: ../trails-api.gen.json post /rpc/Trails/AbortIntent
+---
+
+## Overview
+
+The `AbortIntent` endpoint cancels an in-flight intent after you have submitted the abort transaction on-chain. Once the abort transaction is confirmed, call this endpoint to notify Trails so the intent status is updated to `ABORTED` and any recoverable funds are tracked.
+
+## Use Cases
+
+- Cancel a pending intent that has not yet been processed
+- Recover stuck or expired intents
+- Clean up failed cross-chain transactions
+
+## Request Parameters
+
+### Required Fields
+
+- **intentId** (string): The unique ID of the intent to abort
+- **chainId** (number): The chain ID where the abort transaction was submitted
+- **abortTransactionHash** (string): The transaction hash of the on-chain abort transaction
+
+## Response
+
+- **intentId** (string): The ID of the aborted intent
+- **status** (`IntentStatus`): Updated status of the intent (typically `ABORTED`)
+
+## Examples
+
+### Abort a Pending Intent
+
+```typescript
+const response = await fetch('https://trails-api.sequence.app/rpc/Trails/AbortIntent', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'X-Access-Key': 'YOUR_ACCESS_KEY'
+  },
+  body: JSON.stringify({
+    intentId: 'intent_abc123',
+    chainId: 1,
+    abortTransactionHash: '0xabc123...'
+  })
+});
+
+const { intentId, status } = await response.json();
+console.log(`Intent ${intentId} is now ${status}`);
+```
+
+### With the Trails SDK
+
+```typescript
+import { SequenceTrails } from '0xtrails'
+
+const trails = new SequenceTrails({ accessKey: 'YOUR_ACCESS_KEY' })
+
+const result = await trails.abortIntent({
+  intentId: 'intent_abc123',
+  chainId: 1,
+  abortTransactionHash: '0xabc123...'
+})
+
+console.log('Abort result:', result.status)
+```
+
+<Info>
+You must submit the abort transaction on-chain first and wait for it to be confirmed before calling this endpoint. The `abortTransactionHash` must correspond to a valid on-chain transaction.
+</Info>
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="GetIntentHistory" icon="clock-rotate-left" href="/api-reference/endpoints/get-intent-history">
+    Query intent history including aborted intents
+  </Card>
+
+  <Card title="GetIntent" icon="magnifying-glass" href="/api-reference/endpoints/get-intent">
+    Check current intent status
+  </Card>
+</CardGroup>

--- a/api-reference/endpoints/get-earn-pools.mdx
+++ b/api-reference/endpoints/get-earn-pools.mdx
@@ -1,0 +1,147 @@
+---
+title: GetEarnPools
+openapi: ../trails-api.gen.json post /rpc/Trails/GetEarnPools
+---
+
+## Overview
+
+The `GetEarnPools` endpoint returns aggregated yield-bearing pool information from supported DeFi protocols such as Aave and Morpho. Use this to display earning opportunities to users and build Earn mode integrations.
+
+## Use Cases
+
+- Display yield pools with APY and TVL in your UI
+- Filter pools by chain or protocol
+- Power the Trails Earn mode with live pool data
+- Show users the best yield opportunities across chains
+
+## Request Parameters
+
+All fields are optional.
+
+- **chainIds** (number[]): Filter pools to specific chain IDs
+- **protocols** (string[]): Filter by protocol name (e.g. `"aave"`, `"morpho"`)
+- **minTvl** (number): Minimum total value locked (USD) filter
+- **maxApy** (number): Maximum APY filter
+
+## Response
+
+- **pools** (`EarnPool[]`): Array of yield pool objects
+- **timestamp** (string): ISO timestamp of when this data was fetched
+- **cached** (boolean): Whether the response is from cache
+
+### EarnPool Object Structure
+
+Each pool includes:
+- **id** (string): Unique pool identifier
+- **name** (string): Human-readable pool name
+- **protocol** (string): Protocol name (e.g. `"aave"`, `"morpho"`)
+- **chainId** (number): Chain the pool is deployed on
+- **apy** (number): Current annual percentage yield
+- **tvl** (number): Total value locked in USD
+- **token** (`PoolTokenInfo`): Deposit token details (symbol, name, address, decimals)
+- **depositAddress** (string): Contract address to deposit to
+- **isActive** (boolean): Whether the pool is currently accepting deposits
+- **poolUrl** (string, optional): URL to the pool on the protocol's UI
+- **protocolUrl** (string, optional): URL to the protocol's website
+- **wrappedTokenGatewayAddress** (string, optional): Gateway address for native token deposits
+
+## Examples
+
+### Get All Earn Pools
+
+```typescript
+const response = await fetch('https://trails-api.sequence.app/rpc/Trails/GetEarnPools', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'X-Access-Key': 'YOUR_ACCESS_KEY'
+  },
+  body: JSON.stringify({})
+});
+
+const { pools, timestamp, cached } = await response.json();
+
+console.log(`Fetched ${pools.length} pools (cached: ${cached})`);
+pools.forEach(pool => {
+  console.log(`${pool.name} on chain ${pool.chainId}: ${pool.apy.toFixed(2)}% APY, $${pool.tvl.toLocaleString()} TVL`);
+});
+```
+
+### Filter by Chain and Protocol
+
+```typescript
+const response = await fetch('https://trails-api.sequence.app/rpc/Trails/GetEarnPools', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'X-Access-Key': 'YOUR_ACCESS_KEY'
+  },
+  body: JSON.stringify({
+    chainIds: [8453], // Base only
+    protocols: ['aave'],
+    minTvl: 1000000 // At least $1M TVL
+  })
+});
+
+const { pools } = await response.json();
+```
+
+### Build an Earn Pool List UI
+
+```tsx
+import { useEffect, useState } from 'react';
+
+interface EarnPool {
+  id: string;
+  name: string;
+  protocol: string;
+  chainId: number;
+  apy: number;
+  tvl: number;
+  token: { symbol: string; address: string };
+  depositAddress: string;
+  isActive: boolean;
+}
+
+export const EarnPoolList = ({ chainId }: { chainId?: number }) => {
+  const [pools, setPools] = useState<EarnPool[]>([]);
+
+  useEffect(() => {
+    fetch('https://trails-api.sequence.app/rpc/Trails/GetEarnPools', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Access-Key': 'YOUR_ACCESS_KEY'
+      },
+      body: JSON.stringify({
+        chainIds: chainId ? [chainId] : undefined
+      })
+    })
+      .then(res => res.json())
+      .then(({ pools }) => setPools(pools.filter((p: EarnPool) => p.isActive)));
+  }, [chainId]);
+
+  return (
+    <ul>
+      {pools.map(pool => (
+        <li key={pool.id}>
+          <strong>{pool.name}</strong> — {pool.apy.toFixed(2)}% APY
+          ({pool.token.symbol}, chain {pool.chainId})
+        </li>
+      ))}
+    </ul>
+  );
+};
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Earn Mode" icon="seedling" href="/sdk/modes/earn">
+    Use earn pools in the Trails widget
+  </Card>
+
+  <Card title="GetChains" icon="link" href="/api-reference/endpoints/get-chains">
+    Discover supported chains for earn pools
+  </Card>
+</CardGroup>

--- a/api-reference/endpoints/get-exchange-rate.mdx
+++ b/api-reference/endpoints/get-exchange-rate.mdx
@@ -1,0 +1,92 @@
+---
+title: GetExchangeRate
+openapi: ../trails-api.gen.json post /rpc/Trails/GetExchangeRate
+---
+
+## Overview
+
+The `GetExchangeRate` endpoint returns the current exchange rate for a fiat currency against USD. Use this to display fiat-denominated amounts in your UI or to convert token values to a user's local currency.
+
+## Use Cases
+
+- Display token prices in local fiat currencies
+- Power fiat input mode in fund/withdraw flows
+- Build currency selectors with live exchange rates
+- Show USD-equivalent values in non-USD currencies
+
+## Request Parameters
+
+### Optional Fields
+
+- **toCurrency** (string): ISO 4217 currency code (e.g. `"EUR"`, `"GBP"`, `"JPY"`). Defaults to `"USD"` if omitted.
+
+## Response
+
+- **exchangeRate** (`ExchangeRate`): Exchange rate object
+
+### ExchangeRate Object Structure
+
+- **name** (string): Full name of the currency (e.g. `"Euro"`)
+- **symbol** (string): Currency symbol (e.g. `"€"`)
+- **value** (number): Exchange rate value relative to `vsCurrency`
+- **vsCurrency** (string): The base currency (typically `"USD"`)
+- **currencyType** (string): Currency type identifier
+
+## Examples
+
+### Get EUR Exchange Rate
+
+```typescript
+const response = await fetch('https://trails-api.sequence.app/rpc/Trails/GetExchangeRate', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'X-Access-Key': 'YOUR_ACCESS_KEY'
+  },
+  body: JSON.stringify({ toCurrency: 'EUR' })
+});
+
+const { exchangeRate } = await response.json();
+
+console.log(`1 USD = ${exchangeRate.value} ${exchangeRate.symbol}`);
+// e.g. "1 USD = 0.92 €"
+```
+
+### Convert a USD Amount
+
+```typescript
+async function convertToLocal(usdAmount: number, currency: string): Promise<string> {
+  const response = await fetch('https://trails-api.sequence.app/rpc/Trails/GetExchangeRate', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Access-Key': 'YOUR_ACCESS_KEY'
+    },
+    body: JSON.stringify({ toCurrency: currency })
+  });
+
+  const { exchangeRate } = await response.json();
+  const localAmount = usdAmount * exchangeRate.value;
+
+  return `${exchangeRate.symbol}${localAmount.toFixed(2)}`;
+}
+
+const display = await convertToLocal(100, 'GBP');
+console.log(display); // "£82.50"
+```
+
+<Info>
+Use `GetFiatCurrencyList` to retrieve the full list of supported currencies and their codes before calling this endpoint.
+</Info>
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="GetFiatCurrencyList" icon="money-bill" href="/api-reference/endpoints/get-fiat-currency-list">
+    Get the list of supported fiat currencies
+  </Card>
+
+  <Card title="GetTokenPrices" icon="chart-line" href="/api-reference/endpoints/get-token-prices">
+    Get USD prices for on-chain tokens
+  </Card>
+</CardGroup>

--- a/api-reference/endpoints/get-fiat-currency-list.mdx
+++ b/api-reference/endpoints/get-fiat-currency-list.mdx
@@ -1,0 +1,109 @@
+---
+title: GetFiatCurrencyList
+openapi: ../trails-api.gen.json post /rpc/Trails/GetFiatCurrencyList
+---
+
+## Overview
+
+The `GetFiatCurrencyList` endpoint returns the list of fiat currencies supported for onramp and fiat-denominated displays. Use this to populate currency selectors in fund flows and onramp integrations.
+
+## Use Cases
+
+- Build a currency picker for onramp flows
+- Display flags and symbols for supported currencies
+- Validate that a user's local currency is supported before showing fiat input options
+
+## Request Parameters
+
+This endpoint takes no parameters — send an empty request body.
+
+## Response
+
+- **currencies** (`FiatCurrency[]`): Array of supported fiat currency objects
+
+### FiatCurrency Object Structure
+
+Each currency includes:
+- **code** (string): ISO 4217 currency code (e.g. `"USD"`, `"EUR"`, `"GBP"`)
+- **symbol** (string): Currency symbol (e.g. `"$"`, `"€"`, `"£"`)
+- **name** (string): Full currency name (e.g. `"US Dollar"`)
+- **flag** (string): Emoji flag for the currency's primary country
+- **decimals** (number): Number of decimal places for display
+
+## Examples
+
+### Get All Supported Currencies
+
+```typescript
+const response = await fetch('https://trails-api.sequence.app/rpc/Trails/GetFiatCurrencyList', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'X-Access-Key': 'YOUR_ACCESS_KEY'
+  },
+  body: JSON.stringify({})
+});
+
+const { currencies } = await response.json();
+
+currencies.forEach(c => {
+  console.log(`${c.flag} ${c.name} (${c.code}): ${c.symbol}`);
+});
+```
+
+### Build a Currency Selector
+
+```tsx
+import { useEffect, useState } from 'react';
+
+interface FiatCurrency {
+  code: string;
+  symbol: string;
+  name: string;
+  flag: string;
+  decimals: number;
+}
+
+export const CurrencySelector = ({
+  onSelect
+}: {
+  onSelect: (code: string) => void;
+}) => {
+  const [currencies, setCurrencies] = useState<FiatCurrency[]>([]);
+
+  useEffect(() => {
+    fetch('https://trails-api.sequence.app/rpc/Trails/GetFiatCurrencyList', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Access-Key': 'YOUR_ACCESS_KEY'
+      },
+      body: JSON.stringify({})
+    })
+      .then(res => res.json())
+      .then(({ currencies }) => setCurrencies(currencies));
+  }, []);
+
+  return (
+    <select onChange={(e) => onSelect(e.target.value)}>
+      {currencies.map(c => (
+        <option key={c.code} value={c.code}>
+          {c.flag} {c.name} ({c.code})
+        </option>
+      ))}
+    </select>
+  );
+};
+```
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="GetExchangeRate" icon="arrows-rotate" href="/api-reference/endpoints/get-exchange-rate">
+    Get live exchange rates for a currency
+  </Card>
+
+  <Card title="Fund Mode" icon="wallet" href="/sdk/modes/fund">
+    Use fiat currencies in the fund widget
+  </Card>
+</CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -137,7 +137,21 @@
           {
             "group": "Chains & Discovery",
             "pages": [
-              "api-reference/endpoints/get-chains"
+              "api-reference/endpoints/get-chains",
+              "api-reference/endpoints/get-fiat-currency-list",
+              "api-reference/endpoints/get-exchange-rate"
+            ]
+          },
+          {
+            "group": "Earn",
+            "pages": [
+              "api-reference/endpoints/get-earn-pools"
+            ]
+          },
+          {
+            "group": "Intents (Advanced)",
+            "pages": [
+              "api-reference/endpoints/abort-intent"
             ]
           }
         ]

--- a/sdk/modes/fund.mdx
+++ b/sdk/modes/fund.mdx
@@ -31,8 +31,10 @@ Fund mode implements input-driven deposit flows where users select the amount th
 | `defaultInputMode` | `"fiat" \| "token"` | Default input mode — `"fiat"` starts with fiat currency input (e.g. USD), `"token"` starts with token amount input |
 | `fundOptions` | `object` | Options for customizing fund mode behavior. See [Fund Options](#fund-options) |
 | `slippageTolerance` | `string \| number` | Slippage tolerance (default: 0.5%) |
-| `swapProvider` | `RouteProvider` | Swap provider: `"AUTO"`, `"RELAY"`, `"SUSHI"`, `"ZEROX"`, `"CCTP"` |
-| `bridgeProvider` | `RouteProvider` | Bridge provider: `"AUTO"`, `"RELAY"`, `"CCTP"` |
+| `swapProvider` | `RouteProvider` | Preferred same-chain swap provider: `"AUTO"` (default), `"RELAY"`, `"SUSHI"`, `"ZEROX"`, `"CCTP"`, `"LZ_OFT"`, `"LIFI"`, `"WETH"` |
+| `swapProviderFallback` | `boolean` | When `true`, fall back to another provider if the preferred swap provider is unavailable |
+| `bridgeProvider` | `RouteProvider` | Preferred bridge provider: `"AUTO"` (default), `"RELAY"`, `"CCTP"`, `"LZ_OFT"`, `"LIFI"`, `"WETH"` |
+| `bridgeProviderFallback` | `boolean` | When `true`, fall back to another provider if the preferred bridge provider is unavailable |
 
 ### Fund Options
 
@@ -40,6 +42,8 @@ Fund mode implements input-driven deposit flows where users select the amount th
 |----------|------|---------|-------------|
 | `hideSwap` | `boolean` | `false` | Hide the Swap button in the fund screen header. Useful when swapping is not needed or desired in your integration |
 | `hideWallets` | `string[]` | `[]` | Array of wallet addresses to hide from the funding wallet selection. Useful when you want to prevent specific connected wallets from appearing as funding sources |
+| `fundMethodsList` | `FundMethodListOption[]` | — | Ordered list of funding methods to display. Accepted values: `"connected-wallet"`, `"crypto-transfer"`, `"cc-onramp"`, `"exchange"` |
+| `hideUnlistedMethods` | `boolean` | `false` | If `true`, methods not in `fundMethodsList` are hidden; if `false` (default) they are shown but disabled |
 
 ## Implementation
 
@@ -101,7 +105,9 @@ Control the default input mode and fund-specific UI options:
   defaultInputMode="fiat" // Start with fiat currency input (e.g. USD)
   fundOptions={{
     hideSwap: true, // Hide the Swap button
-    hideWallets: ["0x..."] // Hide specific wallets from funding selection
+    hideWallets: ["0x..."], // Hide specific wallets from funding selection
+    fundMethodsList: ["connected-wallet", "crypto-transfer"], // Only show these methods
+    hideUnlistedMethods: true, // Hide methods not in fundMethodsList
   }}
   onCheckoutComplete={({ sessionId }) => {
     console.log('Deposit completed:', sessionId)
@@ -117,6 +123,8 @@ Control the default input mode and fund-specific UI options:
 | `defaultInputMode="token"` | The amount input starts in token mode (default behavior) |
 | `fundOptions.hideSwap` | Removes the Swap button from the fund screen header, restricting the flow to deposits only |
 | `fundOptions.hideWallets` | Hides specified wallet addresses from the funding wallet selection |
+| `fundOptions.fundMethodsList` | Controls which funding methods are shown and in what order |
+| `fundOptions.hideUnlistedMethods` | When `true`, methods not in `fundMethodsList` are completely hidden |
 
 ### Fixed Amount Deposit
 

--- a/sdk/modes/swap.mdx
+++ b/sdk/modes/swap.mdx
@@ -27,8 +27,10 @@ Swap mode provides a flexible interface for cross-chain token exchanges. Users c
 | `toChainId` | `number` | Pre-select destination chain |
 | `toToken` | `string` | Pre-select destination token |
 | `slippageTolerance` | `string \| number` | Slippage tolerance (default: 0.5%) |
-| `swapProvider` | `RouteProvider` | Swap provider: `"AUTO"`, `"RELAY"`, `"SUSHI"`, `"ZEROX"`, `"CCTP"` |
-| `bridgeProvider` | `RouteProvider` | Bridge provider: `"AUTO"`, `"RELAY"`, `"CCTP"` |
+| `swapProvider` | `RouteProvider` | Preferred same-chain swap provider: `"AUTO"` (default), `"RELAY"`, `"SUSHI"`, `"ZEROX"`, `"CCTP"`, `"LZ_OFT"`, `"LIFI"`, `"WETH"` |
+| `swapProviderFallback` | `boolean` | When `true`, fall back to another provider if the preferred swap provider is unavailable |
+| `bridgeProvider` | `RouteProvider` | Preferred bridge provider: `"AUTO"` (default), `"RELAY"`, `"CCTP"`, `"LZ_OFT"`, `"LIFI"`, `"WETH"` |
+| `bridgeProviderFallback` | `boolean` | When `true`, fall back to another provider if the preferred bridge provider is unavailable |
 
 ## Widget Implementation
 


### PR DESCRIPTION
## Summary

Follow-up to the spec sync (PRs #72–74). Adds missing end-user-facing API reference pages and updates SDK mode documentation to match the current `RouteProvider` enum and new widget props.

### New API reference pages

| Page | Endpoint | Description |
|------|----------|-------------|
| `abort-intent` | `AbortIntent` | Cancel an in-flight intent after submitting the on-chain abort tx |
| `get-earn-pools` | `GetEarnPools` | Fetch yield-bearing pools from Aave/Morpho for Earn mode |
| `get-exchange-rate` | `GetExchangeRate` | Get live fiat exchange rate (used in fiat input mode) |
| `get-fiat-currency-list` | `GetFiatCurrencyList` | List of supported fiat currencies for onramp and display |

### docs.json navigation

- **Chains & Discovery** group: adds `get-fiat-currency-list`, `get-exchange-rate`
- New **Earn** group: `get-earn-pools`
- New **Intents (Advanced)** group: `abort-intent`

### SDK mode page updates

**`sdk/modes/fund.mdx`**
- Updated `swapProvider` values to full `RouteProvider` enum (`LZ_OFT`, `LIFI`, `WETH` added)
- Updated `bridgeProvider` values to full `RouteProvider` enum
- Added `swapProviderFallback` and `bridgeProviderFallback` props
- Added `fundMethodsList` and `hideUnlistedMethods` to the Fund Options table (in sync with `sdk/configuration.mdx`)
- Updated "Customizing Fund Mode" code example to show `fundMethodsList`/`hideUnlistedMethods`

**`sdk/modes/swap.mdx`**
- Updated `swapProvider` values to full `RouteProvider` enum
- Updated `bridgeProvider` values to full `RouteProvider` enum
- Added `swapProviderFallback` and `bridgeProviderFallback` props

## Test plan

- [ ] Verify new endpoint pages render in the API reference sidebar under the correct groups
- [ ] Confirm Mintlify API playground loads for `AbortIntent`, `GetEarnPools`, `GetExchangeRate`, `GetFiatCurrencyList` (spec now includes those paths)
- [ ] Check `sdk/modes/fund.mdx` Fund Options table shows all 4 options
- [ ] Check `sdk/modes/swap.mdx` Optional Props table shows `swapProviderFallback` and `bridgeProviderFallback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)