### PR TITLE
docs: add provider setup guide and fund payment method examples

### DIFF
--- a/sdk/hooks.mdx
+++ b/sdk/hooks.mdx
@@ -28,6 +28,48 @@ import { TrailsProvider } from '0xtrails'
 </TrailsProvider>
 ```
 
+### Apps without wagmi and react-query
+
+The Trails SDK uses wagmi and `@tanstack/react-query` internally. If your app already sets up those providers, `TrailsProvider` will use them automatically.
+
+If your app does not already include these providers, you need to add them above `TrailsProvider`:
+
+```tsx
+'use client'
+
+import { TrailsProvider } from '0xtrails'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createConfig, http, WagmiProvider } from 'wagmi'
+import { arbitrum, base, polygon } from 'wagmi/chains'
+
+const wagmiConfig = createConfig({
+  chains: [base, polygon, arbitrum],
+  transports: {
+    [base.id]: http(),
+    [polygon.id]: http(),
+    [arbitrum.id]: http(),
+  },
+})
+
+const queryClient = new QueryClient()
+
+export const Providers = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <WagmiProvider config={wagmiConfig}>
+      <QueryClientProvider client={queryClient}>
+        <TrailsProvider config={{ trailsApiKey: 'YOUR_API_KEY' }}>
+          {children}
+        </TrailsProvider>
+      </QueryClientProvider>
+    </WagmiProvider>
+  )
+}
+```
+
+<Note>
+This requirement is temporary. A future SDK release will bundle these dependencies so only `TrailsProvider` is needed.
+</Note>
+
 ### Configuration Options
 
 | Option | Type | Required | Description |

--- a/sdk/modes/fund.mdx
+++ b/sdk/modes/fund.mdx
@@ -12,26 +12,48 @@ Fund mode implements input-driven deposit flows where users select the amount th
 
 ## Quick start
 
+Fund supports four payment methods: connected wallet, crypto transfer (QR/address), fiat on-ramp, and exchange (CEX). Set `paymentMethod` to open a specific flow, or omit it to let the user choose.
+
 ```tsx
 import { Fund } from '0xtrails/widget'
 
-// Fully open — user picks everything
-<Fund apiKey="YOUR_API_KEY" />
-```
-
-Pre-set a destination:
-
-```tsx
+// Fiat on-ramp — user buys crypto with a card
 <Fund
   apiKey="YOUR_API_KEY"
-  to={{
-    recipient: "0xYourAddress",
-    currency: "USDC",
-    chain: "base",
-  }}
+  paymentMethod="CREDIT_DEBIT_CARD"
+  from={{ currency: "USD", amount: 100 }}
+  to={{ recipient: "0xYourAddress", currency: "USDC", chain: "base" }}
   onFundingSuccess={({ sessionId }) => console.log("funded", sessionId)}
 />
 ```
+
+```tsx
+// CEX transfer — user sends from their exchange account
+<Fund
+  apiKey="YOUR_API_KEY"
+  paymentMethod="EXCHANGE"
+  from={{ exchange: "coinbase" }}
+  to={{ recipient: "0xYourAddress", currency: "USDC", chain: "base" }}
+/>
+```
+
+<Note>
+The exchange (CEX) flow requires your app to be added to the allowlist. Contact us to get access.
+</Note>
+
+```tsx
+// Connected wallet — user pays from their wallet (default)
+<Fund
+  apiKey="YOUR_API_KEY"
+  paymentMethod="CONNECTED_WALLET"
+  to={{ recipient: "0xYourAddress", currency: "USDC", chain: "base" }}
+/>
+
+// Fully open — let the user pick their preferred method
+<Fund apiKey="YOUR_API_KEY" />
+```
+
+See [Source selection](#source-selection-optional) for all `paymentMethod` values and the `from` options each accepts.
 
 ## Props
 
@@ -62,6 +84,8 @@ Set `paymentMethod` to control how the user funds:
 | `"CRYPTO_TRANSFER"` | QR code / address deposit |
 | `"CREDIT_DEBIT_CARD"` | Fiat on-ramp |
 | `"EXCHANGE"` | CEX transfer (Coinbase, Binance, etc.) |
+
+The `from` prop is fully typed based on the selected `paymentMethod`. TypeScript will narrow the allowed fields automatically, so only valid options for that method are accepted.
 
 When `paymentMethod` is set, the `from` object applies to that method:
 


### PR DESCRIPTION
- Add wagmi + react-query provider setup example to TrailsProvider docs
- Add paymentMethod quick-start flows to Fund page
- Note exchange flow requires allowlist access
- Add note that from prop is typed based on paymentMethod