### PR TITLE
docs: fix GetChains routeProvider — use shared RouteProvider enum, ad…

### DIFF
--- a/api-reference/before-annotations-trails-api.gen.json
+++ b/api-reference/before-annotations-trails-api.gen.json
@@ -1354,6 +1354,7 @@
         "enum": [
           "AUTO",
           "CCTP",
+          "GASZIP",
           "LIFI",
           "LZ_OFT",
           "RELAY",
@@ -3617,7 +3618,7 @@
         "type": "object",
         "properties": {
           "routeProvider": {
-            "type": "string"
+            "$ref": "#/components/schemas/RouteProvider"
           }
         }
       },

--- a/api-reference/trails-api.gen.json
+++ b/api-reference/trails-api.gen.json
@@ -1354,6 +1354,7 @@
         "enum": [
           "AUTO",
           "CCTP",
+          "GASZIP",
           "LIFI",
           "LZ_OFT",
           "RELAY",
@@ -3617,7 +3618,7 @@
         "type": "object",
         "properties": {
           "routeProvider": {
-            "type": "string"
+            "$ref": "#/components/schemas/RouteProvider"
           }
         }
       },

--- a/api-reference/trails-api.gen.yaml
+++ b/api-reference/trails-api.gen.yaml
@@ -995,6 +995,7 @@ components:
       enum:
         - AUTO
         - CCTP
+        - GASZIP
         - LIFI
         - LZ_OFT
         - RELAY
@@ -2585,7 +2586,7 @@ components:
       type: object
       properties:
         routeProvider:
-          type: string
+          $ref: '#/components/schemas/RouteProvider'
     GetChainsResponse:
       type: object
       required:


### PR DESCRIPTION
…d GASZIP

Switches GetChainsRequest.routeProvider from an inline string to $ref RouteProvider so Mintlify renders the shared enum dropdown in the playground. Also adds GASZIP to the RouteProvider enum which was missing from the shared schema.