### PR TITLE
docs: add RetryIntent to API reference

### DIFF
--- a/api-reference/endpoints/retry-intent.mdx
+++ b/api-reference/endpoints/retry-intent.mdx
@@ -1,0 +1,78 @@
+---
+title: RetryIntent
+openapi: ../trails-api.gen.json post /rpc/Trails/RetryIntent
+---
+
+## Overview
+
+The `RetryIntent` endpoint repairs a failed user-submitted deposit flow by validating a replacement deposit transaction hash, marking the deposit leg as confirmed, and requeueing downstream execution.
+
+## Use Cases
+
+- Recover from a failed or dropped deposit transaction
+- Resubmit a deposit with a corrected transaction hash
+- Resume execution of an intent that failed during the deposit phase
+
+## Request Parameters
+
+### Required Fields
+
+- **intentId** (string): The unique ID of the intent to retry
+- **depositTransactionHash** (string): The transaction hash of the new or corrected deposit transaction
+
+## Response
+
+- **intentId** (string): The ID of the retried intent
+- **intentStatus** (`IntentStatus`): Updated status of the intent after retry
+
+## Examples
+
+### Retry a Failed Deposit
+
+```typescript
+const response = await fetch('https://trails-api.sequence.app/rpc/Trails/RetryIntent', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'X-Access-Key': 'YOUR_ACCESS_KEY'
+  },
+  body: JSON.stringify({
+    intentId: 'intent_abc123',
+    depositTransactionHash: '0xnewdeposithash...'
+  })
+});
+
+const { intentId, intentStatus } = await response.json();
+console.log(`Intent ${intentId} is now ${intentStatus}`);
+```
+
+### With the Trails SDK
+
+```typescript
+import { TrailsClient } from '0xtrails'
+
+const trails = new TrailsClient({ accessKey: 'YOUR_ACCESS_KEY' })
+
+const result = await trails.retryIntent({
+  intentId: 'intent_abc123',
+  depositTransactionHash: '0xnewdeposithash...'
+})
+
+console.log('Retry result:', result.intentStatus)
+```
+
+<Info>
+The replacement deposit transaction must be confirmed on-chain before calling this endpoint. The `depositTransactionHash` must correspond to a valid on-chain transaction that deposits the correct token and amount to the intent address.
+</Info>
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="GetIntentReceipt" icon="receipt" href="/api-reference/endpoints/get-intent-receipt">
+    Check the receipt after retrying
+  </Card>
+
+  <Card title="WaitIntentReceipt" icon="clock" href="/api-reference/endpoints/wait-intent-receipt">
+    Stream updates until the intent completes
+  </Card>
+</CardGroup>

--- a/api-reference/trails-api.gen.json
+++ b/api-reference/trails-api.gen.json
@@ -4077,7 +4077,7 @@
         "properties": {
           "queries": {
             "type": "array",
-            "description": "Array of 1–25 balance queries",
+            "description": "Array of 1\u201325 balance queries",
             "minItems": 1,
             "maxItems": 25,
             "items": {
@@ -4131,6 +4131,36 @@
             "type": "object",
             "description": "JSON object containing unsigned transaction payloads",
             "additionalProperties": true
+          }
+        }
+      },
+      "RetryIntentRequest": {
+        "type": "object",
+        "required": [
+          "intentId",
+          "depositTransactionHash"
+        ],
+        "properties": {
+          "intentId": {
+            "type": "string"
+          },
+          "depositTransactionHash": {
+            "type": "string"
+          }
+        }
+      },
+      "RetryIntentResponse": {
+        "type": "object",
+        "required": [
+          "intentId",
+          "intentStatus"
+        ],
+        "properties": {
+          "intentId": {
+            "type": "string"
+          },
+          "intentStatus": {
+            "$ref": "#/components/schemas/IntentStatus"
           }
         }
       }
@@ -9279,6 +9309,187 @@
                     },
                     {
                       "$ref": "#/components/schemas/ErrorUnexpected"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/rpc/Trails/RetryIntent": {
+      "post": {
+        "operationId": "Trails-RetryIntent",
+        "tags": [
+          "Trails"
+        ],
+        "summary": "",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RetryIntentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RetryIntentResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ErrorWebrpcEndpoint"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorWebrpcRequestFailed"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorWebrpcBadRoute"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorWebrpcBadMethod"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorWebrpcBadRequest"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorWebrpcClientAborted"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorWebrpcStreamLost"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorUnauthorized"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorPermissionDenied"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorSessionExpired"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorMethodNotFound"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorRequestConflict"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorAborted"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorGeoblocked"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorRateLimited"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorProjectNotFound"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorAccessKeyNotFound"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorAccessKeyMismatch"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorInvalidOrigin"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorInvalidService"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorUnauthorizedUser"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorQuotaExceeded"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorQuotaRateLimit"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorNoDefaultKey"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorMaxAccessKeys"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorAtLeastOneKey"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorTimeout"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorInvalidArgument"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorUnavailable"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorQueryFailed"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorIntentStatus"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorNotFound"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorUnsupportedNetwork"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorClientOutdated"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorIntentsSkipped"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorQuoteExpired"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorHighPriceImpact"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorIntentsDisabled"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ErrorWebrpcBadResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorWebrpcServerPanic"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorWebrpcInternalError"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorUnexpected"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorChainNodeHealth"
                     }
                   ]
                 }

--- a/docs.json
+++ b/docs.json
@@ -170,7 +170,8 @@
           {
             "group": "Intents (Advanced)",
             "pages": [
-              "api-reference/endpoints/abort-intent"
+              "api-reference/endpoints/abort-intent",
+              "api-reference/endpoints/retry-intent"
             ]
           }
         ]


### PR DESCRIPTION
## Summary
- Add `RetryIntent` endpoint to the OpenAPI spec (`trails-api.gen.json`) with request/response schemas
- Add `retry-intent.mdx` docs page with overview, parameters, response, and usage examples (fetch + SDK)
- Add RetryIntent to the "Intents (Advanced)" navigation group in `docs.json`

## Test plan
- [ ] Verify the docs site builds without errors
- [ ] Confirm RetryIntent appears under API reference > Intents (Advanced)
- [ ] Confirm the OpenAPI interactive panel renders correctly for the endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)