### PR TITLE
docs: update SDK provider setup for 0.16 wagmi-opt-in 2026-05-26

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 scripts/node_modules
 node_modules
 .env
-.DS_Store
+.DS_Storepackage-lock.json

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -152,7 +152,8 @@ import { createWalletClient, createPublicClient, http, encodeFunctionData, erc20
 import { privateKeyToAccount } from 'viem/accounts';
 import { base, arbitrum, mainnet } from 'viem/chains';
 
-// Create clients (or use wagmi hooks: useWalletClient, usePublicClient)
+// Create clients (in React, you can also use the SDK's usePublicClient hook, or
+// useWalletClient from wagmi when paired with @0xtrails/adapter-wagmi)
 const walletClient = createWalletClient({
   account: privateKeyToAccount('0x...'),
   chain: arbitrum, // Set to the origin chain
@@ -215,7 +216,8 @@ import { createWalletClient, createPublicClient, http, encodeFunctionData, erc20
 import { privateKeyToAccount } from 'viem/accounts';
 import { base, arbitrum, mainnet } from 'viem/chains';
 
-// Create clients (or use wagmi hooks: useWalletClient, usePublicClient)
+// Create clients (in React, you can also use the SDK's usePublicClient hook, or
+// useWalletClient from wagmi when paired with @0xtrails/adapter-wagmi)
 const walletClient = createWalletClient({
   account: privateKeyToAccount('0x...'),
   chain: arbitrum, // Set to the origin chain

--- a/examples/refunds.mdx
+++ b/examples/refunds.mdx
@@ -46,6 +46,10 @@ While Trails automatically refunds upon transaction failures, there may be edge 
 
 ### Basic Usage
 
+<Note>
+This example uses wagmi hooks (`useWalletClient`, `useAccount`). Since [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0), wagmi is opt-in — install `@0xtrails/adapter-wagmi` and pass `wagmiAdapter({ wagmiConfig })` in `adapters` for these hooks to resolve. See [SDK Hooks](/sdk/hooks#apps-with-wagmi).
+</Note>
+
 ```tsx
 import { useIntentRecover } from '0xtrails'
 import { useWalletClient, useAccount } from 'wagmi'

--- a/examples/tokens-chains-prices.mdx
+++ b/examples/tokens-chains-prices.mdx
@@ -59,6 +59,10 @@ For fetching prices without balances, use the [GetTokenPrices API](/api-referenc
 
 Build a chain/token selector with live prices:
 
+<Note>
+The `useAccount` import below is from wagmi. Since [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0), wagmi is opt-in — install `@0xtrails/adapter-wagmi` and configure `wagmiAdapter` to use wagmi hooks alongside Trails. See [SDK Hooks](/sdk/hooks#apps-with-wagmi).
+</Note>
+
 ```tsx
 import { useState } from 'react'
 import { useSupportedChains, useSupportedTokens, useTokenBalances } from '0xtrails'

--- a/examples/transaction-history.mdx
+++ b/examples/transaction-history.mdx
@@ -6,6 +6,10 @@ icon: 'clock'
 
 Trails comes with a built in high-performant indexer which you can leverage seamlessly to retrieve information about a user's transaction history.
 
+<Note>
+The examples below import `useAccount` from wagmi. Since [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0), wagmi is opt-in — install `@0xtrails/adapter-wagmi` and configure `wagmiAdapter` to use wagmi hooks alongside Trails. See [SDK Hooks](/sdk/hooks#apps-with-wagmi).
+</Note>
+
 ## Wallet Transaction History
 
 Query a user's transaction history for a specific chain using their connected wallet address:

--- a/examples/wallet-compatibility.mdx
+++ b/examples/wallet-compatibility.mdx
@@ -4,11 +4,15 @@ description: 'Comprehensive wallet integration support and compatibility across 
 icon: 'wallet'
 ---
 
-Trails works with virtually all wallets through wagmi connectors, including embedded wallets like Privy, smart contract wallets like Sequence, or injected EOAs like MetaMask. This enables complex transaction orchestration cross-chain in 1-click without requiring wallets to natively support ERC-7702.
+Trails works with virtually all wallets, including embedded wallets like Privy, smart contract wallets like Sequence, or injected EOAs like MetaMask. This enables complex transaction orchestration cross-chain in 1-click without requiring wallets to natively support ERC-7702.
+
+<Note>
+Since `0xtrails@0.16.0`, Trails uses its own built-in EVM runtime by default — wagmi is no longer required. The patterns below still work for apps that share an existing wagmi session, via the `@0xtrails/adapter-wagmi` package. See the [0.16 release notes](/sdk/changelog/0xtrails-0.16.0) for the migration.
+</Note>
 
 ## How It Works
 
-Trails automatically detects and uses any wagmi connectors configured in your application. Simply wrap your app with a wagmi provider and include the desired wallet connectors in your config.
+Trails detects and uses connected wallets through its built-in runtime, or through wagmi connectors when you install the wagmi adapter. For apps that already use wagmi, wrap your app with a wagmi provider, include the desired wallet connectors in your config, and pass `wagmiAdapter({ wagmiConfig })` to `TrailsProvider`.
 
 ## Basic Wagmi Setup
 

--- a/examples/x402.mdx
+++ b/examples/x402.mdx
@@ -87,6 +87,12 @@ Trails + x402 creates a powerful payment flow:
 pnpm add 0xtrails x402-axios axios
 ```
 
+This example pairs Trails with an existing wagmi + RainbowKit setup. Since [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0), wagmi is opt-in for Trails — also install `@0xtrails/adapter-wagmi` so Trails can share the wagmi session:
+
+```bash
+pnpm add @0xtrails/adapter-wagmi
+```
+
 #### 2. Configure Providers
 
 <CodeGroup>
@@ -95,6 +101,8 @@ import { WagmiProvider, createConfig, http } from "wagmi"
 import { RainbowKitProvider } from "@rainbow-me/rainbowkit"
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query"
 import { mainnet, base } from "wagmi/chains"
+import { TrailsProvider } from "0xtrails"
+import { wagmiAdapter } from "@0xtrails/adapter-wagmi"
 
 const config = createConfig({
   chains: [mainnet, base],
@@ -107,13 +115,17 @@ const config = createConfig({
 
 const queryClient = new QueryClient()
 
+const adapters = [wagmiAdapter({ wagmiConfig: config })]
+
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <WagmiProvider config={config}>
       <QueryClientProvider client={queryClient}>
-        <RainbowKitProvider>
-          {children}
-        </RainbowKitProvider>
+        <TrailsProvider config={{ trailsApiKey: "YOUR_TRAILS_API_KEY", adapters }}>
+          <RainbowKitProvider>
+            {children}
+          </RainbowKitProvider>
+        </TrailsProvider>
       </QueryClientProvider>
     </WagmiProvider>
   )

--- a/resources/supported-chains.mdx
+++ b/resources/supported-chains.mdx
@@ -18,18 +18,17 @@ Trails supports the following mainnet chains with full cross-chain routing capab
 | Avalanche | 43114 | AVAX |
 | BNB Chain | 56 | BNB |
 | Gnosis | 100 | xDAI |
-| Blast | 81457 | ETH |
 | Arbitrum Nova | 42170 | ETH |
 | Ape Chain | 33139 | APE |
 | B3 | 8333 | ETH |
 | Soneium | 1868 | ETH |
-| Xai | 660279 | XAI |
 | Katana | 747474 | ETH |
 | Etherlink | 42793 | XTZ |
 | Berachain | 80094 | BERA |
 | Sonic | 146 | S |
 | Monad | 143 | MON |
 | Somnia | 5031 | SOMI |
+| HyperEVM | 999 | HYPE |
 
 <Note>
 Berachain, Sonic, Monad, and Somnia are newly integrated chains shipping with v1.5. Route coverage and supported token pairs will expand over time.

--- a/sdk/composable-actions/supported-chains.mdx
+++ b/sdk/composable-actions/supported-chains.mdx
@@ -10,9 +10,9 @@ Chain identifiers are either **names** or **chain IDs**. The following names are
 
 ```
 apechain, arbitrum, arbitrum-nova, avalanche, avalanche-c, b3,
-base, binance, bsc, bnb, etherlink, gnosis, hyperevm, katana,
-mainnet, ethereum, monad, optimism, polygon, soneium, somnia,
-sonic, xai
+base, berachain, binance, bsc, bnb, etherlink, gnosis, hyperevm,
+katana, mainnet, ethereum, monad, optimism, polygon, soneium,
+somnia, sonic
 ```
 
 Chain IDs (e.g. `8453` for Base, `42161` for Arbitrum) work interchangeably.

--- a/sdk/configuration.mdx
+++ b/sdk/configuration.mdx
@@ -38,11 +38,13 @@ appMetadata={{
 |------|------|-------------|
 | `walletConnectProjectId` | `string` | WalletConnect project ID |
 | `walletOptions` | `string[]` | Wallet connector IDs to show (e.g. `["metamask", "walletconnect"]`) |
-| `wagmiConnectors` | `Connector[]` | Custom wagmi connectors |
-| `decoupleWagmi` | `boolean` | Decouple from external wagmi provider |
-| `hideDisconnect` | `boolean` | Hide the disconnect button |
+| `adapters` | `TrailsAdapterEntry[]` | Explicit wallet runtime adapters. Use `wagmiAdapter` from [`@0xtrails/adapter-wagmi`](/sdk/hooks#apps-with-wagmi) to share an existing wagmi session, or build your own with `evmAdapter`. |
 | `hideAddWallet` | `boolean` | Hide "Add wallet" option |
 | `isSmartWallet` | `boolean` | Signal that the connected wallet is a smart wallet |
+
+<Note>
+The `wagmiConnectors` and `decoupleWagmi` props were removed in [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0). Wagmi is no longer required by default — pass adapters via the `adapters` prop instead.
+</Note>
 
 #### Route options
 

--- a/sdk/get-started.mdx
+++ b/sdk/get-started.mdx
@@ -60,7 +60,7 @@ export const PaymentExample = () => {
       apiKey="YOUR_API_KEY"
       to={{
         recipient: "0x97c4A952b46bEcaD0663f76357d3776ba11566E1",
-        currency: "USDC",
+        token: "USDC",
         chain: "base",
         amount: "10",
       }}
@@ -85,8 +85,8 @@ export const SwapExample = () => {
   return (
     <Swap
       apiKey="YOUR_API_KEY"
-      from={{ currency: "ETH", chain: "ethereum" }}
-      to={{ currency: "USDC", chain: "base" }}
+      from={{ token: "ETH", chain: "ethereum" }}
+      to={{ token: "USDC", chain: "base" }}
       onSwapSuccess={({ sessionId }) => {
         console.log('Swap completed:', sessionId)
       }}
@@ -110,7 +110,7 @@ export const FundExample = () => {
       apiKey="YOUR_API_KEY"
       to={{
         recipient: "0x97c4A952b46bEcaD0663f76357d3776ba11566E1",
-        currency: "USDC",
+        token: "USDC",
         chain: "base",
       }}
       onFundingSuccess={({ sessionId }) => {
@@ -134,7 +134,7 @@ export const WithdrawExample = () => {
   return (
     <Withdraw
       apiKey="YOUR_API_KEY"
-      from={{ currency: "USDC", chain: "base" }}
+      from={{ token: "USDC", chain: "base" }}
       onWithdrawSuccess={({ sessionId }) => {
         console.log('Withdrawal completed:', sessionId)
       }}
@@ -171,7 +171,7 @@ All focused components expose consistent lifecycle callbacks. Replace `Xxx` with
 ```tsx
 <Pay
   apiKey="YOUR_API_KEY"
-  to={{ recipient: "0x...", currency: "USDC", chain: "base", amount: "10" }}
+  to={{ recipient: "0x...", token: "USDC", chain: "base", amount: "10" }}
   onPaymentStart={({ sessionId }) => {
     console.log('Started:', sessionId)
   }}

--- a/sdk/hooks.mdx
+++ b/sdk/hooks.mdx
@@ -28,18 +28,48 @@ import { TrailsProvider } from '0xtrails'
 </TrailsProvider>
 ```
 
-### Apps without wagmi and react-query
+### Apps without wagmi
 
-The Trails SDK uses wagmi and `@tanstack/react-query` internally. If your app already sets up those providers, `TrailsProvider` will use them automatically.
+<Note>
+Since `0xtrails@0.16.0`, Trails uses a built-in EVM runtime by default and no longer requires wagmi for the widget or the SDK hooks. See the [0.16 release notes](/sdk/changelog/0xtrails-0.16.0) for migration details.
+</Note>
 
-If your app does not already include these providers, you need to add them above `TrailsProvider`:
+The SDK still uses `@tanstack/react-query` internally. If your app does not already include a `QueryClientProvider`, add one above `TrailsProvider`:
 
 ```tsx
 'use client'
 
 import { TrailsProvider } from '0xtrails'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { createConfig, http, WagmiProvider } from 'wagmi'
+
+const queryClient = new QueryClient()
+
+export const Providers = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TrailsProvider config={{ trailsApiKey: 'YOUR_API_KEY' }}>
+        {children}
+      </TrailsProvider>
+    </QueryClientProvider>
+  )
+}
+```
+
+### Apps with wagmi
+
+If your app already uses wagmi and you want Trails to share the same wagmi session, install the wagmi adapter and pass your existing wagmi config through `adapters`:
+
+```bash
+pnpm i @0xtrails/adapter-wagmi
+```
+
+```tsx
+'use client'
+
+import { TrailsProvider } from '0xtrails'
+import { wagmiAdapter } from '@0xtrails/adapter-wagmi'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { WagmiProvider, createConfig, http } from 'wagmi'
 import { arbitrum, base, polygon } from 'wagmi/chains'
 
 const wagmiConfig = createConfig({
@@ -52,12 +82,13 @@ const wagmiConfig = createConfig({
 })
 
 const queryClient = new QueryClient()
+const adapters = [wagmiAdapter({ wagmiConfig })]
 
 export const Providers = ({ children }: { children: React.ReactNode }) => {
   return (
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
-        <TrailsProvider config={{ trailsApiKey: 'YOUR_API_KEY' }}>
+        <TrailsProvider config={{ trailsApiKey: 'YOUR_API_KEY', adapters }}>
           {children}
         </TrailsProvider>
       </QueryClientProvider>
@@ -66,9 +97,7 @@ export const Providers = ({ children }: { children: React.ReactNode }) => {
 }
 ```
 
-<Note>
-This requirement is temporary. A future SDK release will bundle these dependencies so only `TrailsProvider` is needed.
-</Note>
+For custom EIP-1193 wallets without wagmi, use the `evmAdapter` helper exported from `0xtrails` (see the [0.16 release notes](/sdk/changelog/0xtrails-0.16.0#advanced-custom-adapters)).
 
 ### Configuration Options
 

--- a/sdk/hooks.mdx
+++ b/sdk/hooks.mdx
@@ -115,6 +115,49 @@ For custom EIP-1193 wallets without wagmi, use the `evmAdapter` helper exported 
 | `debug` | `boolean` | No | Enable debug logging (default: `false`). |
 | `intentProtocol` | `"v1" \| "v1.5"` | No | Override intent protocol version (default: `"v1.5"`). See [Protocol v1.5](/architecture/v1-5). |
 
+## Wallet adapters
+
+<Note>
+Added in [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0). The `adapters` config controls Trails's wallet runtime. Omit it to use the built-in EVM runtime, or pass adapters to integrate with an existing wallet stack.
+</Note>
+
+### evmAdapter
+
+`evmAdapter` is exported from `0xtrails` for EIP-1193-style wallets (custom in-app wallets, embedded wallets, or any provider that conforms to the EIP-1193 interface).
+
+```tsx
+import { TrailsProvider, evmAdapter } from '0xtrails'
+
+const adapters = [
+  evmAdapter({
+    wallets: {
+      id: 'custom-wallet',
+      name: 'Custom Wallet',
+      provider: customEip1193Provider,
+      iconUrl: '/custom-wallet.svg',
+    },
+  }),
+]
+
+<TrailsProvider config={{ trailsApiKey: 'YOUR_API_KEY', adapters }}>
+  <App />
+</TrailsProvider>
+```
+
+### wagmiAdapter
+
+`wagmiAdapter` lives in the separate `@0xtrails/adapter-wagmi` package and lets Trails share an existing wagmi session. See [Apps with wagmi](#apps-with-wagmi) above for the full setup.
+
+```bash
+pnpm i @0xtrails/adapter-wagmi
+```
+
+```tsx
+import { wagmiAdapter } from '@0xtrails/adapter-wagmi'
+
+const adapters = [wagmiAdapter({ wagmiConfig })]
+```
+
 ## Chains
 
 ```ts
@@ -151,6 +194,31 @@ type Chain = {
   }
   blockExplorerUrls?: string[]
   imageUrl?: string
+}
+```
+
+### Public Clients
+
+<Note>
+Added in [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0). Use these to get a viem `PublicClient` for any supported chain without configuring transports yourself — Trails resolves the RPC via the Sequence node gateway using your API key.
+</Note>
+
+```ts
+import { usePublicClient, usePublicClientGetter } from '0xtrails'
+```
+
+- `usePublicClient(chainId?: number)`: returns a viem `PublicClient | null` for the given chain.
+- `usePublicClientGetter()`: returns a `(chainId: number, retryCount?: number) => PublicClient | null` you can call inside event handlers or effects.
+
+```tsx
+import { usePublicClient, usePublicClientGetter } from '0xtrails'
+
+const base = usePublicClient(8453)
+const getClient = usePublicClientGetter()
+
+async function readBalanceOn(chainId: number, address: `0x${string}`) {
+  const client = getClient(chainId)
+  return client?.getBalance({ address })
 }
 ```
 
@@ -748,6 +816,120 @@ type UseEarnBalancesReturn = {
   error: Error | null
   refetch: () => void
 }
+```
+
+### useResolveActions Hook
+
+<Note>
+Added in [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0). Resolves an array of [composable actions](/sdk/composable-actions/overview) (`lend`, `deposit`, `swap`, `assertCondition`, `custom`) into the concrete `Call[]` you can pass to `useTrailsSendTransaction` or sign directly.
+</Note>
+
+```tsx
+import { useResolveActions, lend, useTrailsClient, usePublicClient } from '0xtrails'
+
+const trailsClient = useTrailsClient()
+const publicClient = usePublicClient(8453)
+
+const { calls, isLoading, error } = useResolveActions({
+  actions: [lend({ marketId: 'base-usdc-aave-v3-lending', amount: '100' })],
+  chainId: 8453,
+  destinationChain: 'base',
+  userWalletAddress: '0xUserAddress',
+  trailsClient,
+  publicClient,
+})
+```
+
+#### Types
+
+```ts
+type UseResolveActionsProps = {
+  actions: ActionItem[]
+  chainId: number | undefined
+  destinationChain: ChainIdentifier
+  userWalletAddress: `0x${string}` | undefined
+  trailsClient: TrailsClient | null
+  publicClient: PublicClient | null
+}
+
+type UseResolveActionsReturn = {
+  calls: Call[] | null
+  isLoading: boolean
+  error: QuoteError | null
+}
+```
+
+## Fiat & Exchange Rates
+
+<Note>
+Added in [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0). Use these to drive fiat-aware UI (currency selectors, USD-to-local-currency displays) without rolling your own pricing source.
+</Note>
+
+```ts
+import { useFiatCurrencyList, useExchangeRate } from '0xtrails'
+```
+
+### useFiatCurrencyList
+
+Returns the list of fiat currencies the Trails API supports for the fiat on-ramp flow. Backed by `@tanstack/react-query`.
+
+```tsx
+const { data: currencies, isLoading } = useFiatCurrencyList()
+```
+
+### useExchangeRate
+
+Fetch the exchange rate between two currencies. Handles same-currency (returns `1`) and direction inversion (e.g. EUR → USD inverts the USD → EUR rate).
+
+```tsx
+const { exchangeRate, isLoading, error } = useExchangeRate({
+  fromCurrency: 'USD',
+  toCurrency: 'EUR',
+})
+```
+
+#### Options
+
+```ts
+type UseExchangeRateOptions = {
+  fromCurrency?: string // ISO 4217, default "USD"
+  toCurrency?: string   // ISO 4217, default "USD"
+  disabled?: boolean    // skip the query
+}
+
+type UseExchangeRateResult = {
+  exchangeRate: number | undefined
+  isLoading: boolean
+  error: Error | null
+}
+```
+
+## Onramp Providers
+
+<Note>
+Added in [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0). Use these to drive your own fiat on-ramp UI (e.g. payment method picker, exchange selector) outside the Trails widget. Backed by Mesh.
+</Note>
+
+```ts
+import { useMeldPaymentMethods, useMeldServiceProviders } from '0xtrails'
+```
+
+### useMeldPaymentMethods
+
+List the payment methods available for a given fiat currency (e.g. `CREDIT_DEBIT_CARD`, `APPLE_PAY`, `GOOGLE_PAY`, `SEPA`, `PAYPAL`).
+
+```tsx
+const { data: methods, isLoading } = useMeldPaymentMethods('EUR')
+```
+
+### useMeldServiceProviders
+
+List the on-ramp service providers available, optionally filtered.
+
+```tsx
+const { data: providers } = useMeldServiceProviders({
+  // any fields of GetMeldServiceProvidersRequest
+})
 ```
 
 ## Constants

--- a/sdk/modes/earn.mdx
+++ b/sdk/modes/earn.mdx
@@ -49,21 +49,33 @@ Pre-configure the destination protocol:
 | Prop | Type | Description |
 |------|------|-------------|
 | `to.recipient` | `string` | Protocol contract address |
-| `to.currency` | `string` | Token to deposit (symbol or address) |
+| `to.token` | `string` | Token to deposit — symbol or contract address |
 | `to.chain` | `ChainIdentifier` | Protocol chain — name, ID, or viem Chain |
-| `to.defaultCurrency` | `string` | Default token — user can change |
+| `to.defaultToken` | `string` | Default token — user can change |
 | `to.defaultChain` | `ChainIdentifier` | Default chain — user can change |
 | `to.amount` | `string \| number` | Fixed deposit amount |
 | `to.calldata` | `string` | ABI-encoded function call to execute after deposit |
 
 ### Source (optional)
 
+The `from` shape is a discriminated union on `paymentMethod`.
+
+**Crypto source** (`paymentMethod` is `"CONNECTED_WALLET"`, `"EXCHANGE"`, `"CRYPTO_TRANSFER"`, or omitted):
+
 | Prop | Type | Description |
 |------|------|-------------|
-| `from.currency` | `string` | Source token symbol or address |
+| `from.token` | `string` | Source ERC-20 token — symbol or contract address |
 | `from.chain` | `ChainIdentifier` | Source chain |
 | `from.amount` | `string \| number` | Source amount |
 | `from.walletAddress` | `string` | Source wallet (defaults to connected wallet) |
+| `from.exchange` | `string` | Mesh exchange key (e.g. `"coinbase"`). `EXCHANGE` arm only. |
+
+**Fiat source** (`paymentMethod` is `"CREDIT_DEBIT_CARD"`):
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `from.currency` | `string` | ISO 4217 fiat code, e.g. `"USD"`, `"EUR"`, `"GBP"` |
+| `from.amount` | `string \| number` | Fiat amount to charge |
 
 ### Payment method (optional)
 

--- a/sdk/modes/fund.mdx
+++ b/sdk/modes/fund.mdx
@@ -22,7 +22,7 @@ import { Fund } from '0xtrails/widget'
   apiKey="YOUR_API_KEY"
   paymentMethod="CREDIT_DEBIT_CARD"
   from={{ currency: "USD", amount: 100 }}
-  to={{ recipient: "0xYourAddress", currency: "USDC", chain: "base" }}
+  to={{ recipient: "0xYourAddress", token: "USDC", chain: "base" }}
   onFundingSuccess={({ sessionId }) => console.log("funded", sessionId)}
 />
 ```
@@ -33,7 +33,7 @@ import { Fund } from '0xtrails/widget'
   apiKey="YOUR_API_KEY"
   paymentMethod="EXCHANGE"
   from={{ exchange: "coinbase" }}
-  to={{ recipient: "0xYourAddress", currency: "USDC", chain: "base" }}
+  to={{ recipient: "0xYourAddress", token: "USDC", chain: "base" }}
 />
 ```
 
@@ -46,7 +46,7 @@ The exchange (CEX) flow requires your app to be added to the allowlist. Contact 
 <Fund
   apiKey="YOUR_API_KEY"
   paymentMethod="CONNECTED_WALLET"
-  to={{ recipient: "0xYourAddress", currency: "USDC", chain: "base" }}
+  to={{ recipient: "0xYourAddress", token: "USDC", chain: "base" }}
 />
 
 // Fully open — let the user pick their preferred method
@@ -68,11 +68,13 @@ See [Source selection](#source-selection-optional) for all `paymentMethod` value
 | Prop | Type | Description |
 |------|------|-------------|
 | `to.recipient` | `string` | Wallet or contract address that receives the funds |
-| `to.currency` | `string` | Token symbol or address |
+| `to.token` | `string` | Destination token — symbol or contract address |
 | `to.chain` | `ChainIdentifier` | Destination chain — name, ID, or viem Chain |
-| `to.defaultCurrency` | `string` | Default token — user can change |
+| `to.defaultToken` | `string` | Default token — user can change |
 | `to.defaultChain` | `ChainIdentifier` | Default chain — user can change |
 | `to.calldata` | `string` | ABI-encoded calldata to execute after funds arrive |
+| `to.supportedChains` | `ChainIdentifier[]` | Restrict destination chains the user can pick |
+| `to.supportedTokensByChain` | `SupportedTokensByChainConfig[]` | Per-chain destination token allowlist |
 
 ### Source selection (optional)
 
@@ -95,7 +97,7 @@ When `paymentMethod` is set, the `from` object applies to that method:
   apiKey="YOUR_API_KEY"
   paymentMethod="CREDIT_DEBIT_CARD"
   from={{ currency: "EUR", amount: 100 }}
-  to={{ currency: "USDC", chain: "base" }}
+  to={{ token: "USDC", chain: "base" }}
 />
 
 // Exchange onramp from Coinbase
@@ -103,7 +105,7 @@ When `paymentMethod` is set, the `from` object applies to that method:
   apiKey="YOUR_API_KEY"
   paymentMethod="EXCHANGE"
   from={{ exchange: "coinbase" }}
-  to={{ currency: "USDC", chain: "base" }}
+  to={{ token: "USDC", chain: "base" }}
 />
 ```
 
@@ -138,7 +140,7 @@ import { Fund } from '0xtrails/widget'
   apiKey="YOUR_API_KEY"
   paymentMethod="CREDIT_DEBIT_CARD"
   from={{ currency: "EUR", amount: 100 }}
-  to={{ currency: "USDC", chain: "base" }}
+  to={{ token: "USDC", chain: "base" }}
   onFundingSuccess={({ sessionId }) => console.log("funded", sessionId)}
 />
 ```
@@ -149,8 +151,8 @@ import { Fund } from '0xtrails/widget'
 <Fund
   apiKey="YOUR_API_KEY"
   paymentMethod="EXCHANGE"
-  from={{ currency: "USDC", chain: "base", exchange: "coinbase" }}
-  to={{ currency: "KAT", chain: "katana" }}
+  from={{ token: "USDC", chain: "base", exchange: "coinbase" }}
+  to={{ token: "KAT", chain: "katana" }}
 />
 ```
 
@@ -162,7 +164,7 @@ import { Fund } from '0xtrails/widget'
   paymentMethod="CRYPTO_TRANSFER"
   to={{
     recipient: "0x...",
-    currency: "USDC",
+    token: "USDC",
     chain: "base",
   }}
 />
@@ -175,7 +177,7 @@ Show only fiat and exchange onramps, hide the rest:
 ```tsx
 <Fund
   apiKey="YOUR_API_KEY"
-  to={{ currency: "USDC", chain: "base" }}
+  to={{ token: "USDC", chain: "base" }}
   fundMethodsList={["cc-onramp", "exchange"]}
   hideUnlistedFundMethods={true}
 />
@@ -209,7 +211,7 @@ To open the exchange flow directly instead of showing the funding method selecto
       environment: 'production',
     },
   }}
-  to={{ recipient: "0xYourAddress", currency: "USDC", chain: "base" }}
+  to={{ recipient: "0xYourAddress", token: "USDC", chain: "base" }}
   onFundingSuccess={({ sessionId }) => console.log("funded", sessionId)}
 />
 ```
@@ -276,7 +278,7 @@ const depositCalldata = encodeFunctionData({
   apiKey="YOUR_API_KEY"
   to={{
     recipient: "0xYearnVault",
-    currency: "USDC",
+    token: "USDC",
     chain: "katana",
     calldata: depositCalldata,
   }}

--- a/sdk/modes/pay.mdx
+++ b/sdk/modes/pay.mdx
@@ -19,7 +19,7 @@ import { Pay } from '0xtrails/widget'
   apiKey="YOUR_API_KEY"
   to={{
     recipient: "0xYourAddress",
-    currency: "USDC",
+    token: "USDC",
     chain: "base",
     amount: "50",
   }}
@@ -48,8 +48,8 @@ Pre-select where the user pays from by adding a `from` object. Omit to let the u
 ```tsx
 <Pay
   apiKey="YOUR_API_KEY"
-  to={{ recipient: "0x...", currency: "USDC", chain: "base", amount: "50" }}
-  from={{ currency: "ETH", chain: "ethereum" }}
+  to={{ recipient: "0x...", token: "USDC", chain: "base", amount: "50" }}
+  from={{ token: "ETH", chain: "ethereum" }}
 />
 ```
 
@@ -68,7 +68,7 @@ To control the payment method, set `paymentMethod`:
 |------|------|-------------|
 | `to.calldata` | `string` | ABI-encoded calldata to execute on the destination chain after payment |
 | `to.defaultChain` | `ChainIdentifier` | Default chain — user can change |
-| `to.defaultCurrency` | `string` | Default token — user can change |
+| `to.defaultToken` | `string` | Default token — user can change |
 
 ### Shared options
 
@@ -107,7 +107,7 @@ import { Pay } from '0xtrails/widget'
   apiKey="YOUR_API_KEY"
   to={{
     recipient: "0xYourMerchantAddress",
-    currency: "USDC",
+    token: "USDC",
     chain: "polygon",
     amount: "25",
   }}
@@ -128,12 +128,12 @@ Lock the user to pay from ETH on Ethereum:
   apiKey="YOUR_API_KEY"
   to={{
     recipient: "0x...",
-    currency: "USDC",
+    token: "USDC",
     chain: "base",
     amount: "50",
   }}
   from={{
-    currency: "ETH",
+    token: "ETH",
     chain: "ethereum",
   }}
   onPaymentSuccess={({ sessionId }) => console.log("paid", sessionId)}
@@ -150,7 +150,7 @@ Let the user pay by sending to an address directly:
   paymentMethod="CRYPTO_TRANSFER"
   to={{
     recipient: "0x...",
-    currency: "USDC",
+    token: "USDC",
     chain: "base",
     amount: "50",
   }}
@@ -167,7 +167,7 @@ Let the user pay with a credit card:
   paymentMethod="CREDIT_DEBIT_CARD"
   to={{
     recipient: "0x...",
-    currency: "USDC",
+    token: "USDC",
     chain: "base",
     amount: "50",
   }}
@@ -198,7 +198,7 @@ const mintCalldata = encodeFunctionData({
   apiKey="YOUR_API_KEY"
   to={{
     recipient: "0xNFT_CONTRACT",
-    currency: "ETH",
+    token: "ETH",
     chain: "arbitrum",
     amount: "0.00002",
     calldata: mintCalldata,
@@ -216,7 +216,7 @@ const mintCalldata = encodeFunctionData({
   apiKey="YOUR_API_KEY"
   to={{
     recipient: "0x...",
-    currency: "USDC",
+    token: "USDC",
     chain: "base",
     amount: "50",
   }}

--- a/sdk/modes/swap.mdx
+++ b/sdk/modes/swap.mdx
@@ -143,6 +143,10 @@ import { Swap } from '0xtrails/widget'
 
 For custom UI, use the `useQuote` hook directly:
 
+<Note>
+This example reads `walletClient` and `address` from wagmi hooks. Since [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0), wagmi is opt-in — install `@0xtrails/adapter-wagmi` and configure `wagmiAdapter` to keep using wagmi alongside Trails. See [SDK Hooks](/sdk/hooks#apps-with-wagmi).
+</Note>
+
 ```tsx
 import { useQuote } from '0xtrails'
 import { useWalletClient, useAccount } from 'wagmi'

--- a/sdk/modes/swap.mdx
+++ b/sdk/modes/swap.mdx
@@ -17,8 +17,8 @@ import { Swap } from '0xtrails/widget'
 
 <Swap
   apiKey="YOUR_API_KEY"
-  from={{ currency: "ETH", chain: "ethereum" }}
-  to={{ currency: "USDC", chain: "base" }}
+  from={{ token: "ETH", chain: "ethereum" }}
+  to={{ token: "USDC", chain: "base" }}
 />
 ```
 
@@ -34,23 +34,37 @@ User picks the amount in the UI.
 
 ### Source (optional)
 
+The `from` shape is a discriminated union on `paymentMethod`. For wallet, exchange, and crypto-transfer flows, source is crypto; for the fiat on-ramp arm, source is fiat.
+
+**When `paymentMethod` is `"CONNECTED_WALLET"`, `"EXCHANGE"`, `"CRYPTO_TRANSFER"`, or omitted (crypto source):**
+
 | Prop | Type | Description |
 |------|------|-------------|
-| `from.currency` | `string` | Pre-select source token symbol or address |
+| `from.token` | `string` | Pre-select source ERC-20 token — symbol (e.g. `"USDC"`) or contract address |
 | `from.chain` | `ChainIdentifier` | Pre-select source chain — name, ID, or viem Chain |
 | `from.amount` | `string \| number` | Pre-fill source amount |
 | `from.walletAddress` | `string` | Source wallet address (defaults to connected wallet) |
+| `from.exchange` | `string` | Mesh exchange key (e.g. `"coinbase"`). `EXCHANGE` arm only. |
+
+**When `paymentMethod` is `"CREDIT_DEBIT_CARD"` (fiat source):**
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `from.currency` | `string` | ISO 4217 fiat code, e.g. `"USD"`, `"EUR"`, `"GBP"` |
+| `from.amount` | `string \| number` | Pre-fill fiat amount |
 
 ### Destination (optional)
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `to.currency` | `string` | Pre-select or lock destination token |
+| `to.token` | `string` | Pre-select or lock destination token — symbol or contract address |
 | `to.chain` | `ChainIdentifier` | Pre-select or lock destination chain |
 | `to.amount` | `string \| number` | Pre-fill destination amount |
-| `to.defaultCurrency` | `string` | Default destination token — user can change |
+| `to.defaultToken` | `string` | Default destination token — user can change |
 | `to.defaultChain` | `ChainIdentifier` | Default destination chain — user can change |
 | `to.calldata` | `string` | ABI-encoded calldata to execute after the swap lands |
+| `to.supportedChains` | `ChainIdentifier[]` | Restrict destination chains the user can pick |
+| `to.supportedTokensByChain` | `SupportedTokensByChainConfig[]` | Per-chain destination token allowlist |
 
 ### Payment method (optional)
 
@@ -101,8 +115,8 @@ import { Swap } from '0xtrails/widget'
 ```tsx
 <Swap
   apiKey="YOUR_API_KEY"
-  from={{ currency: "ETH", chain: "ethereum" }}
-  to={{ currency: "USDC", chain: "base" }}
+  from={{ token: "ETH", chain: "ethereum" }}
+  to={{ token: "USDC", chain: "base" }}
   onSwapSuccess={({ sessionId }) => console.log("swapped", sessionId)}
 />
 ```
@@ -112,7 +126,7 @@ import { Swap } from '0xtrails/widget'
 ```tsx
 <Swap
   apiKey="YOUR_API_KEY"
-  to={{ currency: "USDC", chain: "base" }}
+  to={{ token: "USDC", chain: "base" }}
   onSwapSuccess={({ sessionId }) => console.log("swapped", sessionId)}
 />
 ```
@@ -122,8 +136,8 @@ import { Swap } from '0xtrails/widget'
 ```tsx
 <Swap
   apiKey="YOUR_API_KEY"
-  from={{ currency: "USDC", chain: "ethereum" }}
-  to={{ currency: "USDC", chain: "base", amount: "100" }}
+  from={{ token: "USDC", chain: "ethereum" }}
+  to={{ token: "USDC", chain: "base", amount: "100" }}
   onSwapSuccess={({ sessionId }) => console.log("bridged", sessionId)}
 />
 ```
@@ -134,8 +148,8 @@ import { Swap } from '0xtrails/widget'
 <Swap
   apiKey="YOUR_API_KEY"
   bridgeProvider="CCTP"
-  from={{ currency: "USDC", chain: "ethereum" }}
-  to={{ currency: "USDC", chain: "base" }}
+  from={{ token: "USDC", chain: "ethereum" }}
+  to={{ token: "USDC", chain: "base" }}
 />
 ```
 

--- a/sdk/modes/withdraw.mdx
+++ b/sdk/modes/withdraw.mdx
@@ -17,7 +17,7 @@ import { Withdraw } from '0xtrails/widget'
 
 <Withdraw
   apiKey="YOUR_API_KEY"
-  from={{ currency: "USDC", chain: "base" }}
+  from={{ token: "USDC", chain: "base" }}
 />
 ```
 
@@ -31,21 +31,25 @@ import { Withdraw } from '0xtrails/widget'
 
 ### Source (optional)
 
+Withdraw mode sources funds from crypto only — there is no fiat arm.
+
 | Prop | Type | Description |
 |------|------|-------------|
-| `from.currency` | `string` | Pre-select source token symbol or address |
+| `from.token` | `string` | Pre-select source ERC-20 token — symbol or contract address |
 | `from.chain` | `ChainIdentifier` | Pre-select source chain — name, ID, or viem Chain |
 | `from.amount` | `string \| number` | Pre-fill withdrawal amount |
 | `from.walletAddress` | `string` | Source wallet address (defaults to connected wallet) |
+| `from.supportedChains` | `ChainIdentifier[]` | Restrict origin chains the user can withdraw from |
+| `from.supportedTokensByChain` | `SupportedTokensByChainConfig[]` | Per-chain origin token allowlist |
 
 ### Destination (optional)
 
 | Prop | Type | Description |
 |------|------|-------------|
 | `to.recipient` | `string` | Recipient address (defaults to connected wallet) |
-| `to.currency` | `string` | Controlled destination token — locks selection |
+| `to.token` | `string` | Controlled destination token — locks selection (symbol or contract address) |
 | `to.chain` | `ChainIdentifier` | Controlled destination chain — locks selection |
-| `to.defaultCurrency` | `string` | Default destination token — user can change |
+| `to.defaultToken` | `string` | Default destination token — user can change |
 | `to.defaultChain` | `ChainIdentifier` | Default destination chain — user can change |
 | `to.amount` | `string \| number` | Exact output amount |
 | `to.calldata` | `string` | ABI-encoded calldata to execute at the destination |
@@ -82,10 +86,10 @@ import { Withdraw } from '0xtrails/widget'
 ```tsx
 <Withdraw
   apiKey="YOUR_API_KEY"
-  from={{ currency: "USDC", chain: "base" }}
+  from={{ token: "USDC", chain: "base" }}
   to={{
     recipient: "0xRecipientAddress",
-    defaultCurrency: "ETH",
+    defaultToken: "ETH",
     defaultChain: "ethereum",
   }}
   onWithdrawSuccess={({ sessionId }) => console.log("withdrawn", sessionId)}
@@ -97,9 +101,9 @@ import { Withdraw } from '0xtrails/widget'
 ```tsx
 <Withdraw
   apiKey="YOUR_API_KEY"
-  from={{ currency: "USDC", chain: "base" }}
+  from={{ token: "USDC", chain: "base" }}
   to={{
-    currency: "USDC",
+    token: "USDC",
     chain: "polygon",
   }}
 />

--- a/sdk/quote-providers.mdx
+++ b/sdk/quote-providers.mdx
@@ -31,8 +31,8 @@ import { Swap } from '0xtrails/widget'
   apiKey="YOUR_API_KEY"
   swapProvider="SUSHI"    // Provider for on-chain swaps
   bridgeProvider="RELAY"  // Provider for cross-chain bridging
-  from={{ currency: "USDC", chain: "ethereum" }}
-  to={{ currency: "USDC", chain: "base" }}
+  from={{ token: "USDC", chain: "ethereum" }}
+  to={{ token: "USDC", chain: "base" }}
 />
 ```
 
@@ -97,7 +97,7 @@ Circle's Cross-Chain Transfer Protocol enables native USDC bridging without wrap
 <Swap
   apiKey="YOUR_API_KEY"
   bridgeProvider="CCTP"
-  to={{ currency: "USDC" }}
+  to={{ token: "USDC" }}
 />
 ```
 

--- a/snippets/ChainsAndFees.mdx
+++ b/snippets/ChainsAndFees.mdx
@@ -52,11 +52,6 @@ export const ChainsWithFeesPart2 = ({ env, id }) => {
           <td style={{padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>All</td>
         </tr>
         <tr>
-          <td style={{textTransform: "capitalize", padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>Blast</td>
-          <td style={{padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>81457</td>
-          <td style={{padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>All</td>
-        </tr>
-        <tr>
           <td style={{textTransform: "capitalize", padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>BNB</td>
           <td style={{padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>56</td>
           <td style={{padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>All</td>
@@ -67,9 +62,19 @@ export const ChainsWithFeesPart2 = ({ env, id }) => {
           <td style={{padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>All</td>
         </tr>
         <tr>
+          <td style={{textTransform: "capitalize", padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>Etherlink</td>
+          <td style={{padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>42793</td>
+          <td style={{padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>All</td>
+        </tr>
+        <tr>
           <td style={{textTransform: "capitalize", padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>Gnosis</td>
           <td style={{padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>100</td>
           <td style={{padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>All</td>
+        </tr>
+        <tr>
+          <td style={{textTransform: "capitalize", padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>HyperEVM</td>
+          <td style={{padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>999</td>
+          <td style={{padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>Limited (HYPE)</td>
         </tr>
         <tr>
           <td style={{textTransform: "capitalize", padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>Katana</td>
@@ -112,11 +117,6 @@ export const ChainsWithFeesPart2 = ({ env, id }) => {
           <td style={{textTransform: "capitalize", padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>Sonic</td>
           <td style={{padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>146</td>
           <td style={{padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>Limited (S)</td>
-        </tr>
-        <tr>
-          <td style={{textTransform: "capitalize", padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>Xai</td>
-          <td style={{padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>660279</td>
-          <td style={{padding: "12px 8px", borderBottom: "1px solid #e5e7eb"}}>Limited (XAI)</td>
         </tr>
 
       </tbody>

--- a/use-cases/swap.mdx
+++ b/use-cases/swap.mdx
@@ -88,6 +88,10 @@ export const CCTPSwap = () => {
 
 For custom UI implementations, use the `useQuote` hook directly:
 
+<Note>
+This example pulls `walletClient` and `address` from wagmi hooks. Since [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0), wagmi is opt-in — install `@0xtrails/adapter-wagmi` and configure `wagmiAdapter` to keep using wagmi alongside Trails. See [SDK Hooks](/sdk/hooks#apps-with-wagmi).
+</Note>
+
 ```tsx
 import { useQuote } from '0xtrails'
 import { useWalletClient, useAccount } from 'wagmi'

--- a/use-cases/swap.mdx
+++ b/use-cases/swap.mdx
@@ -50,8 +50,8 @@ export const ETHtoUSDC = () => {
   return (
     <Swap
       apiKey="YOUR_API_KEY"
-      from={{ currency: "ETH", chain: "ethereum" }}
-      to={{ currency: "USDC", chain: "base" }}
+      from={{ token: "ETH", chain: "ethereum" }}
+      to={{ token: "USDC", chain: "base" }}
       onSwapSuccess={({ sessionId }) => {
         console.log('Swap completed:', sessionId)
       }}
@@ -72,8 +72,8 @@ export const CCTPSwap = () => {
     <Swap
       apiKey="YOUR_API_KEY"
       bridgeProvider="CCTP"
-      from={{ currency: "USDC", chain: "ethereum" }}
-      to={{ currency: "USDC", chain: "base" }}
+      from={{ token: "USDC", chain: "ethereum" }}
+      to={{ token: "USDC", chain: "base" }}
       onSwapSuccess={({ sessionId }) => {
         console.log('Swap completed:', sessionId)
       }}


### PR DESCRIPTION
Reflect the `0xtrails@0.16.0` change that makes wagmi opt-in via `@0xtrails/adapter-wagmi`. The hooks reference still showed `WagmiProvider` as a required wrapper.

- sdk/hooks.mdx: split the provider-setup section into "Apps without wagmi" (default in 0.16) and "Apps with wagmi" (use the adapter). Drop the stale "future SDK release" note since the bundled runtime now exists.
- examples/wallet-compatibility.mdx: add a 0.16 note clarifying that wagmi is no longer required and that the existing patterns apply when sharing an existing wagmi session.

Source: trails @ production, 0xtrails@0.16.0 release notes; see the published changelog at sdk/changelog/0xtrails-0.16.0.mdx.