### PR TITLE
docs: update sdk docs 2026-06-01

### DIFF
--- a/resources/supported-chains.mdx
+++ b/resources/supported-chains.mdx
@@ -72,7 +72,6 @@ Trails routes transactions through the optimal liquidity source for each transfe
 | **SushiSwap** | DEX | On-chain swap routing with V3 concentrated liquidity |
 | **0x Protocol** | DEX aggregator | Best execution routing across multiple DEXs |
 | **LayerZero OFT** | Bridge | Omnichain Fungible Token bridge for native cross-chain transfers |
-| **LayerZero Stargate** | Bridge | Native asset bridging via unified Stargate liquidity pools |
 | **Gas.zip** | Bridge | Gas-optimized cross-chain routing |
 
 See [Route Providers](/sdk/quote-providers) for details on configuring bridge and swap providers.

--- a/sdk/quote-providers.mdx
+++ b/sdk/quote-providers.mdx
@@ -15,7 +15,6 @@ Trails integrates with multiple liquidity sources and bridge providers to find t
 - **`SUSHI`**: Uses SushiSwap for on-chain swaps
 - **`ZEROX`**: Uses 0x protocol for DEX aggregation
 - **`LZ_OFT`**: Uses LayerZero Omnichain Fungible Token bridge
-- **`LZ_STARGATE`**: Uses LayerZero Stargate for native asset bridging
 - **`GASZIP`**: Uses Gas.zip for gas-optimized routing
 
 ## Configuration
@@ -120,20 +119,15 @@ SushiSwap provides on-chain swap routing using its V3 concentrated liquidity poo
 <Swap apiKey="YOUR_API_KEY" swapProvider="ZEROX" />
 ```
 
-### LayerZero (LZ_OFT / LZ_STARGATE)
+### LayerZero (LZ_OFT)
 
-LayerZero is an omnichain messaging protocol that powers two distinct bridge providers:
+LayerZero is an omnichain messaging protocol. The `LZ_OFT` provider routes via the Omnichain Fungible Token bridge for tokens that have native OFT deployments across chains (no wrapping, direct cross-chain transfers).
 
-**LZ_OFT** — Omnichain Fungible Token bridge. Used for tokens that have native OFT deployments across chains (no wrapping, direct cross-chain transfers). Live since late February 2025.
-
-**LZ_STARGATE** — Stargate protocol routes native assets across chains using a unified liquidity pool model, minimizing slippage on stable assets.
-
-- Both providers expand coverage to chains and tokens not served by Relay or CCTP
-- AUTO will select the appropriate LayerZero route when it is optimal
+- Expands coverage to chains and tokens not served by Relay or CCTP
+- AUTO will select LZ_OFT when it is the optimal route
 
 ```tsx
-<Swap apiKey="YOUR_API_KEY" bridgeProvider="LZ_OFT" />    // For OFT-enabled tokens
-<Swap apiKey="YOUR_API_KEY" bridgeProvider="LZ_STARGATE" /> // For Stargate native asset routes
+<Swap apiKey="YOUR_API_KEY" bridgeProvider="LZ_OFT" />
 ```
 
 ### Gas.zip


### PR DESCRIPTION
## What changed

- `sdk/quote-providers.mdx` — removes the `LZ_STARGATE` entry from the bullet list of available providers, rewrites the "LayerZero (LZ_OFT / LZ_STARGATE)" section to cover `LZ_OFT` only, and drops the `bridgeProvider="LZ_STARGATE"` code example.
- `resources/supported-chains.mdx` — removes the "LayerZero Stargate" row from the Supported Bridges and Liquidity table.

## Source of truth

- `trails-api/proto/trails-types.ridl` — the canonical `RouteProvider` enum lists `AUTO, CCTP, GASZIP, LIFI, LZ_OFT, RELAY, SUSHI, WETH, ZEROX`. `LZ_STARGATE` is not a member.
- `trails-api/trails.go:262` — the Stargate route provider mapping is commented out: `// routeProviderMap[proto.RouteProvider_LZ_STARGATE] = routeProviders.Stargate`. Stargate is not wired into production.
- `trails-api/proto/validate.go` — `QuoteIntent` rejects any `swapProvider` / `bridgeProvider` value that is not in `RouteProviderMap`, returning `unknown bridgeProvider: <value>`.

A user who copy-pastes the current `bridgeProvider="LZ_STARGATE"` example from the docs would get a request rejected by the API.

## Verification

```
grep -rn "LZ_STARGATE\|Stargate" trails-docs --include='*.mdx' | grep -v changelog
```

After this PR the only remaining matches should be in `sdk/changelog/`, which is intentionally a historical record.

Generated by the Trails Docs weekly agent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4dfQKVehvrA2U74gTUGzJ)_