### PR TITLE
docs: add wallet integration guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -84,6 +84,7 @@
             "pages": [
               "sdk/get-started",
               "sdk/configuration",
+              "sdk/wallet-integration",
               "sdk/hooks",
               {
                 "group": "Composable Actions",

--- a/examples/refunds.mdx
+++ b/examples/refunds.mdx
@@ -47,7 +47,7 @@ While Trails automatically refunds upon transaction failures, there may be edge 
 ### Basic Usage
 
 <Note>
-This example uses wagmi hooks (`useWalletClient`, `useAccount`). Since [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0), wagmi is opt-in — install `@0xtrails/adapter-wagmi` and pass `wagmiAdapter({ wagmiConfig })` in `adapters` for these hooks to resolve. See [SDK Hooks](/sdk/hooks#apps-with-wagmi).
+This example uses wagmi hooks (`useWalletClient`, `useAccount`). Since [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0), wagmi is opt-in — install `@0xtrails/adapter-wagmi` and pass `wagmiAdapter({ wagmiConfig })` in `adapters` for these hooks to resolve. See [Wallet Integration](/sdk/wallet-integration#wagmi).
 </Note>
 
 ```tsx

--- a/examples/tokens-chains-prices.mdx
+++ b/examples/tokens-chains-prices.mdx
@@ -60,7 +60,7 @@ For fetching prices without balances, use the [GetTokenPrices API](/api-referenc
 Build a chain/token selector with live prices:
 
 <Note>
-The `useAccount` import below is from wagmi. Since [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0), wagmi is opt-in — install `@0xtrails/adapter-wagmi` and configure `wagmiAdapter` to use wagmi hooks alongside Trails. See [SDK Hooks](/sdk/hooks#apps-with-wagmi).
+The `useAccount` import below is from wagmi. Since [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0), wagmi is opt-in — install `@0xtrails/adapter-wagmi` and configure `wagmiAdapter` to use wagmi hooks alongside Trails. See [Wallet Integration](/sdk/wallet-integration#wagmi).
 </Note>
 
 ```tsx

--- a/examples/transaction-history.mdx
+++ b/examples/transaction-history.mdx
@@ -7,7 +7,7 @@ icon: 'clock'
 Trails comes with a built in high-performant indexer which you can leverage seamlessly to retrieve information about a user's transaction history.
 
 <Note>
-The examples below import `useAccount` from wagmi. Since [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0), wagmi is opt-in — install `@0xtrails/adapter-wagmi` and configure `wagmiAdapter` to use wagmi hooks alongside Trails. See [SDK Hooks](/sdk/hooks#apps-with-wagmi).
+The examples below import `useAccount` from wagmi. Since [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0), wagmi is opt-in — install `@0xtrails/adapter-wagmi` and configure `wagmiAdapter` to use wagmi hooks alongside Trails. See [Wallet Integration](/sdk/wallet-integration#wagmi).
 </Note>
 
 ## Wallet Transaction History

--- a/examples/wallet-compatibility.mdx
+++ b/examples/wallet-compatibility.mdx
@@ -1,243 +1,193 @@
 ---
 title: 'Wallet Compatibility'
-description: 'Comprehensive wallet integration support and compatibility across different blockchain ecosystems'
+description: 'Comprehensive wallet integration support across built-in wallets, wagmi, Privy, Sequence, and EIP-1193 providers'
 icon: 'wallet'
 ---
 
 Trails works with virtually all wallets, including embedded wallets like Privy, smart contract wallets like Sequence, or injected EOAs like MetaMask. This enables complex transaction orchestration cross-chain in 1-click without requiring wallets to natively support ERC-7702.
 
 <Note>
-Since `0xtrails@0.16.0`, Trails uses its own built-in EVM runtime by default — wagmi is no longer required. The patterns below still work for apps that share an existing wagmi session, via the `@0xtrails/adapter-wagmi` package. See the [0.16 release notes](/sdk/changelog/0xtrails-0.16.0) for the migration.
+Since `0xtrails@0.16.0`, Trails uses its own built-in EVM runtime by default — wagmi is no longer required. Apps that already use wagmi can share that wallet session through `@0xtrails/adapter-wagmi`. See the [0.16 release notes](/sdk/changelog/0xtrails-0.16.0) for migration details.
 </Note>
 
-## How It Works
+For full copy-paste setup snippets, see [Wallet Integration](/sdk/wallet-integration).
 
-Trails detects and uses connected wallets through its built-in runtime, or through wagmi connectors when you install the wagmi adapter. For apps that already use wagmi, wrap your app with a wagmi provider, include the desired wallet connectors in your config, and pass `wagmiAdapter({ wagmiConfig })` to `TrailsProvider`.
+## How it works
 
-## Basic Wagmi Setup
+Trails can connect wallets in two ways:
+
+1. Use the built-in wallet runtime, which is the default and requires no wallet provider setup.
+2. Pass an explicit adapter when your app already manages wallets through wagmi, Privy, Sequence, or a custom EIP-1193 provider.
+
+## Pick an integration path
+
+| Wallet setup | Recommended Trails integration |
+|--------------|--------------------------------|
+| No existing wallet setup | Use the [built-in wallet runtime](/sdk/wallet-integration#built-in-wallet-runtime) |
+| Existing wagmi app | Use [`wagmiAdapter`](/sdk/wallet-integration#wagmi) with the same `wagmiConfig` |
+| Sequence Embedded Wallet | Use Sequence's wagmi config with [`wagmiAdapter`](/sdk/wallet-integration#wagmi) |
+| Privy embedded wallet with wagmi | Use Privy's wagmi config with [`wagmiAdapter`](/sdk/wallet-integration#privy-with-wagmi) |
+| Privy embedded wallet without wagmi | Use Privy's EIP-1193 provider with [`evmAdapter`](/sdk/wallet-integration#privy-without-wagmi) |
+| Custom EIP-1193 provider | Use [`evmAdapter`](/sdk/wallet-integration#custom-eip-1193-providers) from `0xtrails` |
+
+## Built-in wallet runtime
+
+This is the simplest path. If your app does not already use wagmi, Privy, Sequence, or another wallet system, render a Trails widget or focused component directly.
 
 ```tsx
-import { createConfig, http, WagmiProvider } from 'wagmi'
-import { mainnet, base, arbitrum } from 'wagmi/chains'
-import { injected, walletConnect } from 'wagmi/connectors'
 import { Pay } from '0xtrails/widget'
 
-const config = createConfig({
-  chains: [mainnet, base, arbitrum],
-  connectors: [
-    injected(),
-    walletConnect({ projectId: 'your-walletconnect-project-id' })
-  ],
-  transports: {
-    [mainnet.id]: http(),
-    [base.id]: http(),
-    [arbitrum.id]: http(),
-  },
+export function Checkout() {
+  return (
+    <Pay
+      apiKey="YOUR_API_KEY"
+      to={{ recipient: '0x...', token: 'USDC', chain: 'base', amount: '25' }}
+    />
+  )
+}
+```
+
+## wagmi
+
+Use wagmi only when your app already has a `WagmiProvider` and Trails should share that session.
+
+```tsx
+import { wagmiAdapter } from '@0xtrails/adapter-wagmi'
+
+const adapters = [wagmiAdapter({ wagmiConfig })]
+```
+
+Checklist:
+
+- Install `0xtrails`, `@0xtrails/adapter-wagmi`, `wagmi`, `viem`, and `@tanstack/react-query`.
+- Reuse the exact same `wagmiConfig` instance for `WagmiProvider` and `wagmiAdapter(...)`.
+- Put adapters on either `TrailsProvider config.adapters` or a widget/focused component `adapters` prop, not both.
+
+### Sequence Embedded Wallet
+
+Sequence's current Embedded Wallet Web SDK is wagmi-based. Configure Sequence with `@0xsequence/connect`, then pass `sequenceConfig.wagmiConfig` to Trails.
+
+```tsx
+import { createConfig, SequenceConnect } from '@0xsequence/connect'
+import { wagmiAdapter } from '@0xtrails/adapter-wagmi'
+import { TrailsProvider } from '0xtrails'
+import { Pay } from '0xtrails/widget'
+
+const sequenceConfig = createConfig('waas', {
+  projectAccessKey: 'YOUR_SEQUENCE_PROJECT_ACCESS_KEY',
+  waasConfigKey: 'YOUR_SEQUENCE_WAAS_CONFIG_KEY',
+  appName: 'Your App',
+  chainIds: [8453],
+  defaultChainId: 8453,
 })
+
+const adapters = [wagmiAdapter({ wagmiConfig: sequenceConfig.wagmiConfig })]
 
 export function App() {
   return (
-    <WagmiProvider config={config}>
-      <Pay
-        apiKey="YOUR_API_KEY"
-        to={{
-          recipient: "0x...",
-          currency: "USDC",
-          chain: "arbitrum",
-          amount: "1000",
-        }}
-      />
-    </WagmiProvider>
+    <SequenceConnect config={sequenceConfig}>
+      <TrailsProvider config={{ trailsApiKey: 'YOUR_API_KEY', adapters }}>
+        <Pay to={{ recipient: '0x...', token: 'USDC', chain: 'base', amount: '25' }} />
+      </TrailsProvider>
+    </SequenceConnect>
   )
 }
 ```
 
-## Sequence Wallet Integration
+Do not pass the whole Sequence config object to Trails; pass `sequenceConfig.wagmiConfig`.
 
-Integrate Sequence smart contract wallets for enhanced security and user experience:
-
-```tsx
-import { createConfig, http, WagmiProvider } from 'wagmi'
-import { mainnet, base, arbitrum } from 'wagmi/chains'
-import { sequenceWallet } from '@0xsequence/wagmi-connector'
-import { Pay } from '0xtrails/widget'
-
-// Create Sequence connector
-const sequenceConnector = sequenceWallet({
-  connectOptions: {
-    app: "Your App Name",
-    apiKey: "your-sequence-project-key",
-  },
-  defaultNetwork: 1, // Mainnet
-  walletAppURL: "https://sequence.app",
-})
-
-const config = createConfig({
-  chains: [mainnet, base, arbitrum],
-  connectors: [sequenceConnector],
-  transports: {
-    [mainnet.id]: http(),
-    [base.id]: http(),
-    [arbitrum.id]: http(),
-  },
-})
-
-export function AppWithSequence() {
-  return (
-    <WagmiProvider config={config}>
-      <Pay
-        apiKey="YOUR_API_KEY"
-        to={{
-          recipient: "0x...",
-          currency: "USDC",
-          chain: "arbitrum",
-          amount: "1000",
-        }}
-      />
-    </WagmiProvider>
-  )
-}
-```
-
-## Privy Embedded Wallets
+## Privy embedded wallets
 
 Integrate Privy for seamless embedded wallet experiences. You can try live demos below:
 
 - [Headless SDK demo](https://demo-trails-privy-embedded.0xsequence.workers.dev/)
 - [Widget demo](https://demo-trails-modal-privy-embedded.0xsequence.workers.dev/)
 
-```tsx
-import React from 'react';
-import { PrivyProvider } from '@privy-io/react-auth';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { mainnet } from 'wagmi/chains';
-import { createConfig, WagmiProvider } from '@privy-io/wagmi';
-import { http } from 'wagmi';
-import { Pay } from '0xtrails/widget';
+Privy works with Trails either through wagmi or directly through Privy's EIP-1193 provider.
 
-const config = createConfig({
-  chains: [mainnet],
-  transports: {
-    [mainnet.id]: http(),
-  },
-});
+### Privy with wagmi
 
-const queryClient = new QueryClient();
-
-export function AppWithPrivy() {
-  return (
-    <PrivyProvider
-      appId="your-privy-app-id"
-      config={{
-        embeddedWallets: {
-          ethereum: {
-            createOnLogin: 'users-without-wallets',
-          },
-        },
-      }}
-    >
-      <QueryClientProvider client={queryClient}>
-        <WagmiProvider config={config}>
-          <Pay
-            apiKey="YOUR_API_KEY"
-            to={{
-              recipient: "0x...",
-              currency: "USDC",
-              chain: "arbitrum",
-              amount: "1000",
-            }}
-          />
-        </WagmiProvider>
-      </QueryClientProvider>
-    </PrivyProvider>
-  )
-}
-```
-
-## Multiple Wallet Support
-
-Combine multiple wallet connectors to give users choice:
+Use this when your app already uses wagmi hooks or wants Privy to manage the active wagmi wallet.
 
 ```tsx
-import { createConfig, http, WagmiProvider } from 'wagmi'
-import { mainnet, base, arbitrum } from 'wagmi/chains'
-import { injected, walletConnect } from 'wagmi/connectors'
-import { sequenceWallet } from '@0xsequence/wagmi-connector'
-import { createPrivyWalletConnector } from '@privy-io/wagmi-connector'
 import { PrivyProvider } from '@privy-io/react-auth'
-import { Pay } from '0xtrails/widget'
+import { createConfig, WagmiProvider } from '@privy-io/wagmi'
+import { wagmiAdapter } from '@0xtrails/adapter-wagmi'
+import { http } from 'wagmi'
+import { base } from 'wagmi/chains'
 
-// Create all connectors
-const sequenceConnector = sequenceWallet({
-  connectOptions: {
-    app: "Your App",
-    apiKey: "your-sequence-key",
-  },
-  defaultNetwork: 1,
+const wagmiConfig = createConfig({
+  chains: [base],
+  transports: { [base.id]: http() },
 })
 
-const privyConnector = createPrivyWalletConnector({
-  appId: "your-privy-app-id",
-  name: "Privy",
-})
-
-const config = createConfig({
-  chains: [mainnet, base, arbitrum],
-  connectors: [
-    injected(),
-    walletConnect({ projectId: 'your-walletconnect-project-id' }),
-    sequenceConnector,
-    privyConnector,
-  ],
-  transports: {
-    [mainnet.id]: http(),
-    [base.id]: http(),
-    [arbitrum.id]: http(),
-  },
-})
-
-export function MultiWalletApp() {
-  return (
-    <PrivyProvider
-      appId="your-privy-app-id"
-      config={{
-        loginMethods: ["email", "google"],
-        embeddedWallets: { createOnLogin: "all-users" },
-      }}
-    >
-      <WagmiProvider config={config}>
-        <Pay
-          apiKey="YOUR_API_KEY"
-          to={{
-            recipient: "0x...",
-            currency: "USDC",
-            chain: "arbitrum",
-            amount: "1000",
-          }}
-        />
-      </WagmiProvider>
-    </PrivyProvider>
-  )
-}
+const adapters = [wagmiAdapter({ wagmiConfig })]
 ```
 
-## Supported Wallet Types
+Wrap `PrivyProvider`, `QueryClientProvider`, `WagmiProvider`, and `TrailsProvider` with that same config. See the [full Privy with wagmi setup](/sdk/wallet-integration#privy-with-wagmi).
 
-Trails works with all wagmi-compatible wallets including:
+### Privy without wagmi
 
-- **Injected Wallets**: MetaMask, Coinbase Wallet, Brave Wallet
-- **WalletConnect**: Any wallet supporting WalletConnect protocol
-- **Smart Contract Wallets**: Sequence, Safe, Biconomy
-- **Embedded Wallets**: Privy, Dynamic, Magic
-- **Mobile Wallets**: Rainbow, Trust Wallet, Phantom
-- **Hardware Wallets**: Ledger, Trezor (via connectors)
+Use this when your app wants Privy embedded wallets but does not want wagmi. Read the connected Privy wallet with `useWallets()`, get its EIP-1193 provider, then pass it to `evmAdapter`.
 
-## Key Benefits
+```tsx
+import { useWallets } from '@privy-io/react-auth'
+import { evmAdapter } from '0xtrails'
 
-- **Universal Compatibility**: Works with any wagmi connector
-- **No Wallet Modifications**: Wallets don't need ERC-7702, 4337, or other external dependencies
-- **Cross-Chain Transactions**: Complex multi-chain operations in 1-click
-- **Flexible Integration**: Use existing wallet infrastructure
-- **Future-Proof**: Automatically supports new wagmi connectors
+const { wallets } = useWallets()
+const embeddedWallet = wallets.find((wallet) => wallet.walletClientType === 'privy')
+const provider = await embeddedWallet?.getEthereumProvider()
 
-For more configuration options, see our [Configuration Guide](/sdk/configuration).
+const adapters = provider
+  ? [
+      evmAdapter({
+        wallets: {
+          id: 'privy-embedded-wallet',
+          name: 'Privy Embedded Wallet',
+          provider,
+        },
+      }),
+    ]
+  : undefined
+```
+
+Render Trails only after Privy is ready and the provider exists. See the [full Privy without wagmi setup](/sdk/wallet-integration#privy-without-wagmi).
+
+## Custom EIP-1193 providers
+
+Use `evmAdapter` for any non-wagmi wallet that exposes a standard EIP-1193 provider.
+
+```tsx
+import { evmAdapter } from '0xtrails'
+
+const adapters = [
+  evmAdapter({
+    wallets: {
+      id: 'custom-wallet',
+      name: 'Custom Wallet',
+      provider: customEip1193Provider,
+      iconUrl: '/custom-wallet.svg',
+    },
+  }),
+]
+```
+
+## Supported wallet types
+
+Trails supports common wallet setups including:
+
+- **Built-in wallet runtime**: no wallet provider setup required
+- **Injected wallets**: MetaMask, Coinbase Wallet, Brave Wallet
+- **WalletConnect**: any wallet supporting WalletConnect
+- **Smart contract wallets**: Sequence, Safe, Biconomy
+- **Embedded wallets**: Privy, Dynamic, Magic
+- **Custom EIP-1193 providers**: in-app wallets, embedded wallets, or custom signers
+
+## Key benefits
+
+- **Universal compatibility**: Works with the built-in runtime, wagmi, or standard EIP-1193 providers
+- **No wallet modifications**: Wallets don't need ERC-7702, 4337, or other external dependencies
+- **Cross-chain transactions**: Complex multi-chain operations in 1-click
+- **Flexible integration**: Use Trails directly or share your existing wallet infrastructure
+
+For more configuration options, see the [Wallet Integration](/sdk/wallet-integration) and [Configuration Guide](/sdk/configuration).

--- a/get-started.mdx
+++ b/get-started.mdx
@@ -93,4 +93,4 @@ All are imported from `0xtrails/widget`.
 
 ---
 
-**Full reference**: [SDK Configuration](/sdk/configuration) · [API Reference](/api-reference/introduction) · [Hooks](/sdk/hooks)
+**Full reference**: [SDK Configuration](/sdk/configuration) · [Wallet Integration](/sdk/wallet-integration) · [API Reference](/api-reference/introduction) · [Hooks](/sdk/hooks)

--- a/sdk/configuration.mdx
+++ b/sdk/configuration.mdx
@@ -32,19 +32,23 @@ appMetadata={{
 }}
 ```
 
-#### Wallet options
+#### Wallet runtime options
+
+By default, standalone widgets and focused components use Trails' built-in EVM wallet runtime. If your app already has a wallet setup, pass explicit adapters on either `TrailsProvider config.adapters` or the widget/focused component `adapters` prop.
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `walletConnectProjectId` | `string` | WalletConnect project ID |
-| `walletOptions` | `string[]` | Wallet connector IDs to show (e.g. `["metamask", "walletconnect"]`) |
-| `adapters` | `TrailsAdapterEntry[]` | Explicit wallet runtime adapters. Use `wagmiAdapter` from [`@0xtrails/adapter-wagmi`](/sdk/hooks#apps-with-wagmi) to share an existing wagmi session, or build your own with `evmAdapter`. |
+| `walletConnectProjectId` | `string` | WalletConnect project ID for the built-in wallet runtime |
+| `walletOptions` | `string[]` | Built-in wallet connector IDs to show (for example, `["metamask", "walletconnect"]`) |
+| `adapters` | `TrailsAdapterEntry[]` | Explicit wallet adapters; use either provider-level or widget-level adapters, not both |
 | `hideAddWallet` | `boolean` | Hide "Add wallet" option |
 | `isSmartWallet` | `boolean` | Signal that the connected wallet is a smart wallet |
 
 <Note>
 The `wagmiConnectors` and `decoupleWagmi` props were removed in [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0). Wagmi is no longer required by default — pass adapters via the `adapters` prop instead.
 </Note>
+
+Use `@0xtrails/adapter-wagmi` for existing wagmi apps, and use `evmAdapter` from `0xtrails` for non-wagmi EVM providers. See [Wallet Integration](/sdk/wallet-integration).
 
 #### Route options
 
@@ -115,4 +119,3 @@ See the individual mode pages for full prop details:
 - [Swap](/sdk/modes/swap) — `from`, `to`, `onSwapStart/Success/Error`
 - [Withdraw](/sdk/modes/withdraw) — `from`, `to`, `onWithdrawStart/Success/Error`
 - [Earn](/sdk/modes/earn) — `to` with `calldata`, `onEarnStart/Success/Error`
-

--- a/sdk/get-started.mdx
+++ b/sdk/get-started.mdx
@@ -47,6 +47,8 @@ bun add 0xtrails
 
 The SDK exports `Pay`, `Fund`, `Swap`, `Withdraw`, and `Earn` as purpose-built alternatives to `TrailsWidget`. Pick the component that matches what you're building.
 
+For widget-only usage, no wallet providers are required. When there is no parent wallet context and no `adapters` prop, Trails uses its built-in EVM wallet runtime.
+
 ### Pay
 
 User pays a specific amount to a specific recipient:
@@ -223,4 +225,4 @@ Pin to a specific version (e.g. `@1.5.0`) in production instead of `@latest`.
 
 Detailed configuration: [Pay](/sdk/modes/pay) · [Fund](/sdk/modes/fund) · [Swap](/sdk/modes/swap) · [Withdraw](/sdk/modes/withdraw) · [Earn](/sdk/modes/earn)
 
-If you need hooks: wrap your app with `TrailsProvider`. See the [Hooks documentation](/sdk/hooks#trailsprovider).
+If you need hooks: wrap your app with `QueryClientProvider` and `TrailsProvider`. If your app already has a wallet setup, pass explicit adapters. See [Hooks](/sdk/hooks#trailsprovider) and [Wallet Integration](/sdk/wallet-integration).

--- a/sdk/hooks.mdx
+++ b/sdk/hooks.mdx
@@ -12,35 +12,13 @@ All hooks and utilities are available from the `0xtrails` package unless stated 
 **Required for Hooks**: The `TrailsProvider` must wrap your application when using any Trails hooks. This provider configures the necessary context for all hook functionality.
 </Warning>
 
-```tsx
-import { TrailsProvider } from '0xtrails'
-
-<TrailsProvider
-  config={{
-    trailsApiKey: "...",
-    trailsApiUrl: "...",            // optional
-    sequenceIndexerUrl: "...",      // optional
-    sequenceNodeGatewayUrl: "...",  // optional
-    intentProtocol: "v1.5",        // optional — defaults to v1.5
-  }}
->
-  <App />
-</TrailsProvider>
-```
-
-### Apps without wagmi
-
-<Note>
-Since `0xtrails@0.16.0`, Trails uses a built-in EVM runtime by default and no longer requires wagmi for the widget or the SDK hooks. See the [0.16 release notes](/sdk/changelog/0xtrails-0.16.0) for migration details.
-</Note>
-
-The SDK still uses `@tanstack/react-query` internally. If your app does not already include a `QueryClientProvider`, add one above `TrailsProvider`:
+Hooks require `@tanstack/react-query` and `TrailsProvider`:
 
 ```tsx
 'use client'
 
-import { TrailsProvider } from '0xtrails'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TrailsProvider } from '0xtrails'
 
 const queryClient = new QueryClient()
 
@@ -55,62 +33,26 @@ export const Providers = ({ children }: { children: React.ReactNode }) => {
 }
 ```
 
+`TrailsProvider` uses the built-in EVM wallet runtime by default. Add `config.adapters` only when Trails should share an existing wallet setup.
+
 ### Apps with wagmi
 
-If your app already uses wagmi and you want Trails to share the same wagmi session, install the wagmi adapter and pass your existing wagmi config through `adapters`:
+If your app already uses wagmi, install `@0xtrails/adapter-wagmi` and pass the same `wagmiConfig` instance to both `WagmiProvider` and `wagmiAdapter(...)`. See [Wallet Integration](/sdk/wallet-integration#wagmi) for the full setup, including Sequence and Privy wagmi examples.
 
-```bash
-pnpm i @0xtrails/adapter-wagmi
-```
-
-```tsx
-'use client'
-
-import { TrailsProvider } from '0xtrails'
-import { wagmiAdapter } from '@0xtrails/adapter-wagmi'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { WagmiProvider, createConfig, http } from 'wagmi'
-import { arbitrum, base, polygon } from 'wagmi/chains'
-
-const wagmiConfig = createConfig({
-  chains: [base, polygon, arbitrum],
-  transports: {
-    [base.id]: http(),
-    [polygon.id]: http(),
-    [arbitrum.id]: http(),
-  },
-})
-
-const queryClient = new QueryClient()
-const adapters = [wagmiAdapter({ wagmiConfig })]
-
-export const Providers = ({ children }: { children: React.ReactNode }) => {
-  return (
-    <WagmiProvider config={wagmiConfig}>
-      <QueryClientProvider client={queryClient}>
-        <TrailsProvider config={{ trailsApiKey: 'YOUR_API_KEY', adapters }}>
-          {children}
-        </TrailsProvider>
-      </QueryClientProvider>
-    </WagmiProvider>
-  )
-}
-```
-
-For custom EIP-1193 wallets without wagmi, use the `evmAdapter` helper exported from `0xtrails` (see the [0.16 release notes](/sdk/changelog/0xtrails-0.16.0#advanced-custom-adapters)).
+For hook-first execution flows, use an explicit adapter unless the hook documents a direct `walletClient` option. For non-wagmi embedded wallets or custom providers, see [Custom EIP-1193 providers](/sdk/wallet-integration#custom-eip-1193-providers).
 
 ### Configuration Options
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
-| `trailsApiKey` | `string` | Yes | Your Trails API key. Get your API key from the [Trails Dashboard](https://dashboard.trails.build/landing)
- |
+| `trailsApiKey` | `string` | Yes | Your Trails API key. Get your API key from the [Trails Dashboard](https://dashboard.trails.build/landing). |
 | `trailsApiUrl` | `string` | No | Custom API endpoint URL if using a self-hosted instance. |
 | `sequenceIndexerUrl` | `string` | No | Custom Sequence indexer URL. |
 | `sequenceNodeGatewayUrl` | `string` | No | Custom Sequence node gateway URL. |
 | `sequenceMetadataUrl` | `string` | No | Custom Sequence metadata URL. |
 | `sequenceApiUrl` | `string` | No | Custom Sequence API URL. |
-| `walletConnectProjectId` | `string` | No | WalletConnect project ID for wallet connections. |
+| `walletConnectProjectId` | `string` | No | WalletConnect project ID for built-in wallet connections. |
+| `adapters` | `TrailsAdapterEntry[]` | No | Wallet adapters for wagmi or EIP-1193 integrations. |
 | `slippageTolerance` | `string \| number` | No | Default slippage tolerance for swaps (e.g., `0.005` for 0.5%). |
 | `debug` | `boolean` | No | Enable debug logging (default: `false`). |
 | `intentProtocol` | `"v1" \| "v1.5"` | No | Override intent protocol version (default: `"v1.5"`). See [Protocol v1.5](/architecture/v1-5). |
@@ -118,7 +60,7 @@ For custom EIP-1193 wallets without wagmi, use the `evmAdapter` helper exported 
 ## Wallet adapters
 
 <Note>
-Added in [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0). The `adapters` config controls Trails's wallet runtime. Omit it to use the built-in EVM runtime, or pass adapters to integrate with an existing wallet stack.
+Added in [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0). Omit `adapters` to use the built-in EVM runtime, or pass adapters to integrate with an existing wallet setup.
 </Note>
 
 ### evmAdapter
@@ -146,7 +88,7 @@ const adapters = [
 
 ### wagmiAdapter
 
-`wagmiAdapter` lives in the separate `@0xtrails/adapter-wagmi` package and lets Trails share an existing wagmi session. See [Apps with wagmi](#apps-with-wagmi) above for the full setup.
+`wagmiAdapter` lives in the separate `@0xtrails/adapter-wagmi` package and lets Trails share an existing wagmi session. See [Wallet Integration](/sdk/wallet-integration#wagmi) for full wagmi, Sequence, and Privy examples.
 
 ```bash
 pnpm i @0xtrails/adapter-wagmi

--- a/sdk/modes/swap.mdx
+++ b/sdk/modes/swap.mdx
@@ -158,7 +158,7 @@ import { Swap } from '0xtrails/widget'
 For custom UI, use the `useQuote` hook directly:
 
 <Note>
-This example reads `walletClient` and `address` from wagmi hooks. Since [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0), wagmi is opt-in — install `@0xtrails/adapter-wagmi` and configure `wagmiAdapter` to keep using wagmi alongside Trails. See [SDK Hooks](/sdk/hooks#apps-with-wagmi).
+This example reads `walletClient` and `address` from wagmi hooks. Since [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0), wagmi is opt-in — install `@0xtrails/adapter-wagmi` and configure `wagmiAdapter` to keep using wagmi alongside Trails. See [Wallet Integration](/sdk/wallet-integration#wagmi).
 </Note>
 
 ```tsx

--- a/sdk/wallet-integration.mdx
+++ b/sdk/wallet-integration.mdx
@@ -1,0 +1,348 @@
+---
+title: Wallet Integration
+description: "Use Trails with the built-in runtime, wagmi, Privy, or custom EIP-1193 providers"
+sidebarTitle: "Wallet Integration"
+---
+
+Trails works with virtually all EVM wallets. By default, Trails uses its built-in wallet runtime, so most apps can render a widget or focused component directly. Add an adapter only when your app already has a wallet setup that Trails should share.
+
+## Pick an integration path
+
+| Your app has | Use | Install |
+|--------------|-----|---------|
+| No wallet setup | Built-in Trails runtime | `0xtrails` |
+| Existing wagmi app | `wagmiAdapter({ wagmiConfig })` | `0xtrails @0xtrails/adapter-wagmi wagmi viem @tanstack/react-query` |
+| Sequence Embedded Wallet | Sequence's wagmi config with `wagmiAdapter(...)` | `0xtrails @0xtrails/adapter-wagmi @0xsequence/connect @0xsequence/hooks wagmi ethers viem 0xsequence @tanstack/react-query` |
+| Privy embedded wallets with wagmi | Privy's wagmi config with `wagmiAdapter(...)` | `0xtrails @0xtrails/adapter-wagmi @privy-io/react-auth @privy-io/wagmi wagmi viem @tanstack/react-query` |
+| Privy embedded wallets without wagmi | Privy's EIP-1193 provider with `evmAdapter(...)` | `0xtrails @privy-io/react-auth @tanstack/react-query` |
+| Custom EIP-1193 provider | `evmAdapter({ wallets })` | `0xtrails @tanstack/react-query` |
+
+<Note>
+If your app already manages wallets, pass an explicit adapter to either `TrailsProvider config.adapters` or a widget/focused component `adapters` prop.
+</Note>
+
+## Built-in wallet runtime
+
+Use this path when your app does not already configure wallets. No `WagmiProvider`, `PrivyProvider`, or external wallet connector is required for widget-only usage.
+
+```tsx
+import { Pay } from '0xtrails/widget'
+
+export function Checkout() {
+  return (
+    <Pay
+      apiKey="YOUR_API_KEY"
+      to={{ recipient: '0x...', token: 'USDC', chain: 'base', amount: '25' }}
+    />
+  )
+}
+```
+
+For hooks, add `QueryClientProvider` and `TrailsProvider`:
+
+```tsx
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TrailsProvider } from '0xtrails'
+
+const queryClient = new QueryClient()
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TrailsProvider config={{ trailsApiKey: 'YOUR_API_KEY' }}>
+        {children}
+      </TrailsProvider>
+    </QueryClientProvider>
+  )
+}
+```
+
+## wagmi
+
+Use this path when your app already uses wagmi and Trails should share the same connected account, chain, and wallet session.
+
+```bash
+pnpm add 0xtrails @0xtrails/adapter-wagmi wagmi viem @tanstack/react-query
+```
+
+Create one wagmi config and pass the exact same object to `WagmiProvider` and `wagmiAdapter(...)`:
+
+```tsx
+'use client'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { wagmiAdapter } from '@0xtrails/adapter-wagmi'
+import { TrailsProvider } from '0xtrails'
+import { Pay } from '0xtrails/widget'
+import { WagmiProvider, createConfig, http } from 'wagmi'
+import { base, mainnet } from 'wagmi/chains'
+import { injected, walletConnect } from 'wagmi/connectors'
+
+const wagmiConfig = createConfig({
+  chains: [base, mainnet],
+  connectors: [
+    injected(),
+    walletConnect({ projectId: 'YOUR_WALLETCONNECT_PROJECT_ID' }),
+  ],
+  transports: {
+    [base.id]: http(),
+    [mainnet.id]: http(),
+  },
+})
+
+const queryClient = new QueryClient()
+const adapters = [wagmiAdapter({ wagmiConfig })]
+
+export function App() {
+  return (
+    <WagmiProvider config={wagmiConfig}>
+      <QueryClientProvider client={queryClient}>
+        <TrailsProvider config={{ trailsApiKey: 'YOUR_API_KEY', adapters }}>
+          <Pay to={{ recipient: '0x...', token: 'USDC', chain: 'base', amount: '25' }} />
+        </TrailsProvider>
+      </QueryClientProvider>
+    </WagmiProvider>
+  )
+}
+```
+
+For a widget-only page already wrapped by `WagmiProvider`, you can put `apiKey` and `adapters` directly on the focused component instead of using `TrailsProvider`. Do not configure adapters in both places.
+
+### Sequence Embedded Wallet
+
+The current Sequence Embedded Wallet Web SDK is wagmi-based. Configure Sequence with `@0xsequence/connect`, then pass `sequenceConfig.wagmiConfig` to Trails.
+
+```bash
+pnpm add 0xtrails @0xtrails/adapter-wagmi @0xsequence/connect @0xsequence/hooks wagmi ethers viem 0xsequence @tanstack/react-query
+```
+
+```tsx
+'use client'
+
+import { createConfig, SequenceConnect } from '@0xsequence/connect'
+import { wagmiAdapter } from '@0xtrails/adapter-wagmi'
+import { TrailsProvider } from '0xtrails'
+import { Pay } from '0xtrails/widget'
+
+const sequenceConfig = createConfig('waas', {
+  projectAccessKey: 'YOUR_SEQUENCE_PROJECT_ACCESS_KEY',
+  waasConfigKey: 'YOUR_SEQUENCE_WAAS_CONFIG_KEY',
+  appName: 'Your App',
+  chainIds: [8453, 1],
+  defaultChainId: 8453,
+})
+
+const adapters = [
+  wagmiAdapter({ wagmiConfig: sequenceConfig.wagmiConfig }),
+]
+
+export function App() {
+  return (
+    <SequenceConnect config={sequenceConfig}>
+      <TrailsProvider config={{ trailsApiKey: 'YOUR_API_KEY', adapters }}>
+        <Pay to={{ recipient: '0x...', token: 'USDC', chain: 'base', amount: '25' }} />
+      </TrailsProvider>
+    </SequenceConnect>
+  )
+}
+```
+
+Pass `sequenceConfig.wagmiConfig`, not the full Sequence config object. If your app uses Sequence's lower-level provider APIs, keep the same rule: Trails needs the wagmi config used by the active Sequence wallet session.
+
+## Privy embedded wallets
+
+Privy can integrate with Trails in two ways:
+
+- **With wagmi**: recommended when your app already uses wagmi hooks or wants Privy to manage the active wagmi wallet.
+- **Without wagmi**: use Privy's EIP-1193 provider directly with `evmAdapter`.
+
+### Privy with wagmi
+
+Privy's wagmi integration uses `createConfig` and `WagmiProvider` from `@privy-io/wagmi`. Pass that same config to `wagmiAdapter(...)`.
+
+```bash
+pnpm add 0xtrails @0xtrails/adapter-wagmi @privy-io/react-auth @privy-io/wagmi wagmi viem @tanstack/react-query
+```
+
+```tsx
+'use client'
+
+import { PrivyProvider } from '@privy-io/react-auth'
+import { createConfig, WagmiProvider } from '@privy-io/wagmi'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { wagmiAdapter } from '@0xtrails/adapter-wagmi'
+import { TrailsProvider } from '0xtrails'
+import { Pay } from '0xtrails/widget'
+import { http } from 'wagmi'
+import { base, mainnet } from 'wagmi/chains'
+
+const wagmiConfig = createConfig({
+  chains: [base, mainnet],
+  transports: {
+    [base.id]: http(),
+    [mainnet.id]: http(),
+  },
+})
+
+const queryClient = new QueryClient()
+const adapters = [wagmiAdapter({ wagmiConfig })]
+
+export function App() {
+  return (
+    <PrivyProvider
+      appId="YOUR_PRIVY_APP_ID"
+      config={{
+        supportedChains: [base, mainnet],
+        defaultChain: base,
+        embeddedWallets: {
+          ethereum: {
+            createOnLogin: 'users-without-wallets',
+          },
+        },
+      }}
+    >
+      <QueryClientProvider client={queryClient}>
+        <WagmiProvider config={wagmiConfig}>
+          <TrailsProvider config={{ trailsApiKey: 'YOUR_API_KEY', adapters }}>
+            <Pay to={{ recipient: '0x...', token: 'USDC', chain: 'base', amount: '25' }} />
+          </TrailsProvider>
+        </WagmiProvider>
+      </QueryClientProvider>
+    </PrivyProvider>
+  )
+}
+```
+
+Use this setup for both Privy embedded wallets and Privy-connected external wallets when your app wants wagmi hooks such as `useAccount` or `useWalletClient`.
+
+### Privy without wagmi
+
+Use this path when your app uses Privy embedded wallets but does not want wagmi. Privy's connected wallets expose an EIP-1193 provider through `wallet.getEthereumProvider()`, which can be passed to `evmAdapter`.
+
+```bash
+pnpm add 0xtrails @privy-io/react-auth @tanstack/react-query
+```
+
+```tsx
+'use client'
+
+import { PrivyProvider, usePrivy, useWallets } from '@privy-io/react-auth'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TrailsProvider, evmAdapter, type TrailsAdapterEntry } from '0xtrails'
+import { Pay } from '0xtrails/widget'
+import { useEffect, useState } from 'react'
+
+const queryClient = new QueryClient()
+
+function TrailsWithPrivyWallet() {
+  const { ready, authenticated, login } = usePrivy()
+  const { wallets } = useWallets()
+  const [adapters, setAdapters] = useState<TrailsAdapterEntry[]>()
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadPrivyWallet() {
+      const embeddedWallet = wallets.find(
+        (wallet) => wallet.walletClientType === 'privy',
+      )
+
+      if (!ready || !authenticated || !embeddedWallet) {
+        setAdapters(undefined)
+        return
+      }
+
+      const provider = await embeddedWallet.getEthereumProvider()
+
+      if (!cancelled) {
+        setAdapters([
+          evmAdapter({
+            wallets: {
+              id: 'privy-embedded-wallet',
+              name: 'Privy Embedded Wallet',
+              provider,
+            },
+          }),
+        ])
+      }
+    }
+
+    loadPrivyWallet()
+
+    return () => {
+      cancelled = true
+    }
+  }, [ready, authenticated, wallets])
+
+  if (!ready) return null
+  if (!authenticated) return <button onClick={login}>Log in</button>
+  if (!adapters) return <div>Loading wallet...</div>
+
+  return (
+    <TrailsProvider config={{ trailsApiKey: 'YOUR_API_KEY', adapters }}>
+      <Pay to={{ recipient: '0x...', token: 'USDC', chain: 'base', amount: '25' }} />
+    </TrailsProvider>
+  )
+}
+
+export function App() {
+  return (
+    <PrivyProvider
+      appId="YOUR_PRIVY_APP_ID"
+      config={{
+        embeddedWallets: {
+          ethereum: {
+            createOnLogin: 'users-without-wallets',
+          },
+        },
+      }}
+    >
+      <QueryClientProvider client={queryClient}>
+        <TrailsWithPrivyWallet />
+      </QueryClientProvider>
+    </PrivyProvider>
+  )
+}
+```
+
+Render a connect or loading state until Privy is ready and an embedded wallet is available. If you want Trails to use a different Privy wallet, select that wallet from `useWallets()` before creating the adapter.
+
+## Custom EIP-1193 providers
+
+Use `evmAdapter` for non-wagmi wallets that expose an EIP-1193 provider: custom in-app wallets, embedded wallets, or any provider with a `request({ method, params })` API.
+
+```tsx
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TrailsProvider, evmAdapter } from '0xtrails'
+
+const queryClient = new QueryClient()
+const adapters = [
+  evmAdapter({
+    wallets: {
+      id: 'in-app-wallet',
+      name: 'In-app Wallet',
+      provider: eip1193Provider,
+      iconUrl: '/wallet.svg',
+    },
+  }),
+]
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TrailsProvider config={{ trailsApiKey: 'YOUR_API_KEY', adapters }}>
+        {children}
+      </TrailsProvider>
+    </QueryClientProvider>
+  )
+}
+```
+
+## Rules
+
+- Do not add wagmi only for Trails. Use the built-in runtime unless your app already uses wagmi.
+- Reuse the exact same wagmi config instance for `WagmiProvider` and `wagmiAdapter(...)`.
+- For Sequence, pass `sequenceConfig.wagmiConfig`, not the whole Sequence config.
+- For Privy without wagmi, wait for `wallet.getEthereumProvider()` before rendering Trails with `evmAdapter`.
+- Keep `queryClient`, wagmi config, Sequence config, and adapter arrays outside React components when they are static.
+- Put adapters on either `TrailsProvider config.adapters` or a widget/focused component `adapters` prop, not both.

--- a/use-cases/swap.mdx
+++ b/use-cases/swap.mdx
@@ -89,7 +89,7 @@ export const CCTPSwap = () => {
 For custom UI implementations, use the `useQuote` hook directly:
 
 <Note>
-This example pulls `walletClient` and `address` from wagmi hooks. Since [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0), wagmi is opt-in — install `@0xtrails/adapter-wagmi` and configure `wagmiAdapter` to keep using wagmi alongside Trails. See [SDK Hooks](/sdk/hooks#apps-with-wagmi).
+This example pulls `walletClient` and `address` from wagmi hooks. Since [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0), wagmi is opt-in — install `@0xtrails/adapter-wagmi` and configure `wagmiAdapter` to keep using wagmi alongside Trails. See [Wallet Integration](/sdk/wallet-integration#wagmi).
 </Note>
 
 ```tsx


### PR DESCRIPTION
## Summary

- Add a dedicated Wallet Integration SDK page covering built-in wallets, wagmi, Sequence Embedded Wallet, Privy with/without wagmi, and custom EIP-1193 providers.
- Restore the Wallet Compatibility example as a simple overview with clearer old positioning language and links to full setup snippets.
- Update related hooks/configuration/get-started references and stale wagmi setup anchors.

## Validation

- `git diff --check`
- `pnpm test`
