### PR TITLE
docs: update architecture docs 2026-06-29

### DIFF
--- a/architecture/smart-contracts.mdx
+++ b/architecture/smart-contracts.mdx
@@ -42,6 +42,11 @@ The Trails protocol consists of several core smart contracts:
 - **TrailsIntentEntrypoint** - Entry point for intent deposits with permit support
 - **TrailsRouterShim** - Execution wrapper with sentinel tracking for success/failure states
 - **HydrateProxy** - Runtime value injection for v1.5 intents. Resolves dynamic amounts and addresses (ERC-20 balances, intent wallet address) at execution time, enabling composable actions with `dynamic()` without committing exact amounts at quote time
+- **MalleableSapient** - Sapient signer that authorizes commitments whose calldata is hydrated on-chain (the signer module behind HydrateProxy)
+- **RequireUtils** - Precondition checks used inside intent execution to fail fast when on-chain state diverges from quote-time assumptions
+- **TrailsUtils** - Convenience contract that bundles `MalleableSapient`, `HydrateProxy`, and `RequireUtils` under a single deployed address. Its address is now returned by the API as `trailsUtilsAddress` alongside the other Trails contract addresses.
+- **TimedRefundSapient** - Sapient signer that authorizes a refund payload after a per-intent unlock timestamp. Combined with the API's intent recovery endpoints, lets users self-recover funds stranded in a counterfactual intent wallet after the configured timeout.
+- **PausableSapient** / **Pausable** - Sapient signer wrapping any inner signer with a circuit breaker. A set of designated operators can pause signature acceptance to halt new intent commitments without redeploying contracts; operator changes are emitted as events for observability.
 
 All contracts leverage Sequence v3 account abstraction for flexible, secure cross-chain operations.
 


### PR DESCRIPTION
## What changed

`architecture/smart-contracts.mdx`: extended the Key Contracts list with the contracts that have shipped to `trails-contracts` `master` but are not yet documented.

- **TrailsUtils** — convenience contract that bundles `MalleableSapient`, `HydrateProxy`, and `RequireUtils` under one deployed address. Its address is also now returned by the API as `trailsUtilsAddress` on the `TrailsContracts` payload.
- **TimedRefundSapient** — sapient signer that authorizes a refund payload after a per-intent unlock timestamp. Pairs with the new `PrepareIntentRecovery` / `BuildIntentRecoveryTransaction` API endpoints documented separately.
- **PausableSapient** / **Pausable** — sapient signer wrapping any inner signer with a circuit breaker; designated operators can pause signature acceptance to halt new intent commitments.
- **MalleableSapient** and **RequireUtils** — already deployed and used by v1.5 flows; previously only `HydrateProxy` (which depends on them) was mentioned.

## Source of truth

- `TrailsUtils.sol` — [trails-contracts/src/TrailsUtils.sol](https://github.com/0xsequence/trails-contracts/blob/master/src/TrailsUtils.sol). Its address became a required field on the `TrailsContracts` API schema in [trails-api `release`](https://github.com/0xsequence/trails-api/blob/release/proto/trails-api.ridl) (`trailsUtilsAddress`).
- `TimedRefundSapient.sol` — [trails-contracts/src/autoRecovery/TimedRefundSapient.sol](https://github.com/0xsequence/trails-contracts/blob/master/src/autoRecovery/TimedRefundSapient.sol), added in [#92 (2026-03-17)](https://github.com/0xsequence/trails-contracts/pull/92).
- `Pausable.sol` and `PausableSapient.sol` — [trails-contracts/src/pausable/](https://github.com/0xsequence/trails-contracts/tree/master/src/pausable), added in [#96 (2026-06-25)](https://github.com/0xsequence/trails-contracts/pull/96).
- `MalleableSapient.sol` and `RequireUtils.sol` — [trails-contracts/src/modules/](https://github.com/0xsequence/trails-contracts/tree/master/src/modules); both are inherited by `TrailsUtils`.

## Verification

- Compare the bullet list against `ls trails-contracts/src/**/*.sol` — every contract in `src/` plus the modules used by `TrailsUtils` is now mentioned.
- Cross-reference the `trailsUtilsAddress` field against `TrailsContracts` in `trails-api/proto/trails-types.ridl`.

Generated by the Trails Docs weekly agent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWNzSfFgq1KuPsVhSUdz2o)_