### PR TITLE
docs: update resources 2026-06-29

### DIFF
--- a/resources/supported-chains.mdx
+++ b/resources/supported-chains.mdx
@@ -73,9 +73,27 @@ Trails routes transactions through the optimal liquidity source for each transfe
 | **0x Protocol** | DEX aggregator | Best execution routing across multiple DEXs |
 | **LayerZero OFT** | Bridge | Omnichain Fungible Token bridge for native cross-chain transfers |
 | **LayerZero Stargate** | Bridge | Native asset bridging via unified Stargate liquidity pools |
+| **LayerZero Value Transfer** | Bridge | Direct cross-chain value transfers via LayerZero (`LZ_TRANSFER`) |
+| **Hyperlane** | Bridge | Permissionless interchain messaging; routed when a warp route exists for the token pair |
+| **OIF** | Bridge | Open Intents Framework — solver-filled cross-chain intents (explicit selection only) |
 | **Gas.zip** | Bridge | Gas-optimized cross-chain routing |
+| **Somnia Exchange** | DEX | On-chain swaps native to Somnia |
+| **Somnia Swap** | DEX | On-chain swaps native to Somnia |
 
 See [Route Providers](/sdk/quote-providers) for details on configuring bridge and swap providers.
+
+## Non-EVM Edge Rails
+
+In addition to EVM chains, Trails supports **edge rails** that bridge between non-EVM chains and the EVM intent flow. Edge rails are used as either the origin (funds enter the intent from a non-EVM chain) or destination (intent funds an address on a non-EVM chain) of a cross-chain intent.
+
+| Chain | Edge Modes |
+|-------|------------|
+| Solana | Origin, Destination |
+| Tron | Origin, Destination |
+
+Edge-rail availability can vary by deployment. Call [`GetEdges`](/api-reference/endpoints/get-edges) to discover which rails and modes are enabled, then use [`QuoteIntentEdge`](/api-reference/endpoints/quote-intent-edge) instead of `QuoteIntent` to price any intent that touches a non-EVM chain. Track the external leg with [`GetEdgeStatus`](/api-reference/endpoints/get-edge-status).
+
+In the SDK, Solana wallets are wired in through the [`svmAdapter`](/sdk/adapters/solana).
 
 ## Request a New Chain
 


### PR DESCRIPTION
## What changed

`resources/supported-chains.mdx`:

- Added **Hyperlane**, **OIF**, **LayerZero Value Transfer** (`LZ_TRANSFER`), and **Somnia Exchange** / **Somnia Swap** to the "Supported Bridges and Liquidity" table. The bridge/DEX list now matches the `RouteProvider` enum from the API.
- Added a new "Non-EVM Edge Rails" section documenting **Solana** and **Tron** support, with cross-links to the new `GetEdges`, `QuoteIntentEdge`, and `GetEdgeStatus` API endpoints and to the Solana SDK adapter page.

## Source of truth

- `RouteProvider` enum in [`trails-api/proto/docs/trails-api.gen.yaml`](https://github.com/0xsequence/trails-api/blob/release/proto/docs/trails-api.gen.yaml) — current values are `AUTO, CCTP, GASZIP, HYPERLANE, LIFI, LZ_OFT, LZ_TRANSFER, OIF, RELAY, SOMNIA_EXCHANGE, SOMNIA_SWAP, SUSHI, WETH, ZEROX`.
- `EdgeRail` enum (Solana, Tron) + `EdgeMode` (Origin, Destination) in the same spec, exposed via the `Trails.GetEdges` RPC.
- Existing per-provider detail already covered in [`sdk/quote-providers.mdx`](https://github.com/0xsequence/trails-docs/blob/main/sdk/quote-providers.mdx) — this PR just brings the resources summary table in sync.

## Verification

- Cross-check each row against the `RouteProvider` enum in `trails-api/proto/docs/trails-api.gen.yaml`.
- Cross-check the edge-rail table against the `EdgeRail` / `EdgeMode` enums and the `Trails.GetEdges` response shape (`EdgeRailModes`).
- `pnpm test` (mintlify broken-links) — verify the new cross-links to `/api-reference/endpoints/get-edges`, `/api-reference/endpoints/quote-intent-edge`, `/api-reference/endpoints/get-edge-status` and `/sdk/adapters/solana` resolve.

The endpoint cross-links depend on #97 landing first (where the new endpoint pages are added).

Generated by the Trails Docs weekly agent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWNzSfFgq1KuPsVhSUdz2o)_