### PR TITLE
docs: document edge chains and alternative VM support

### DIFF
--- a/architecture/edge-alt-vms.mdx
+++ b/architecture/edge-alt-vms.mdx
@@ -1,0 +1,63 @@
+---
+title: 'Edge & Alternative VMs'
+description: 'How Trails extends beyond EVM to non-EVM chains via edge rails'
+icon: 'circle-nodes'
+---
+
+Trails routes across more than one virtual machine. Beyond EVM networks, it reaches **alternative VMs** — non-EVM ecosystems such as SVM chains — through a mechanism called **edge rails**. Every alternative-VM chain is an edge chain.
+
+This page explains the model. For the current list of supported edge chains, see [Supported Chains](/resources/supported-chains). For which SDK hooks are edge-aware, see [Hooks → Edge chains](/sdk/hooks#edge-chains).
+
+## Edge rails
+
+An **edge rail** is the route that connects a non-EVM ecosystem to the EVM intent graph. Trails does not run a separate protocol per VM; instead, an edge chain sits at the *edge* of a flow — as the origin the user funds from, or the destination funds settle into — while the intent itself is anchored in the EVM-based orchestration described in [How Trails Works](/architecture/how-it-works).
+
+Because the model is keyed on the *rail*, not the specific chain, new alternative VMs are added by registering a new edge rail rather than by reworking the routing layer.
+
+## Origin vs. destination
+
+Edge support is asymmetric. What an integration needs depends on whether the edge chain is the **origin** (where funds come from) or the **destination** (where funds land).
+
+| | Origin (pay *from* an edge chain) | Destination (pay *to* an edge chain) |
+|--|--|--|
+| **Wallet required** | An edge-chain wallet (non-EVM) | A standard EVM wallet |
+| **SDK adapter** | Required — the matching edge wallet [adapter](/sdk/adapters/overview) | Not required |
+| **What the user signs** | A transaction in their edge-chain wallet | Nothing on the edge chain |
+| **Recipient** | — | An edge-chain address |
+
+**Why origin needs an adapter.** A non-EVM chain uses its own signing scheme and transaction format — an EVM `walletClient` (viem) cannot produce a valid signature for it. Executing an edge-origin transaction therefore requires an ecosystem-native signer, supplied by the edge wallet adapter registered on `TrailsProvider`. Without it, edge-origin execution is unavailable and the SDK surfaces an explicit error.
+
+**Why destination does not.** When an edge chain is only the destination, the user still signs a single EVM origin transaction as usual. Trails routes the value across the edge rail and settles to the edge-chain recipient address — no edge wallet or adapter is involved on the user's side.
+
+## Execution flow
+
+An edge-origin transaction follows the same intent lifecycle as an EVM flow (see [How Trails Works](/architecture/how-it-works)), with the origin leg executed on the edge chain:
+
+1. **Quote.** The route is quoted across the edge rail. Edge origin and destination are both quoted through the same intent quote path; edge chains are addressed by their ecosystem-native chain ID.
+2. **Origin execution.** The user signs and submits the origin transaction with their edge-chain wallet via the edge adapter. Funds enter the edge rail.
+3. **Bridging & settlement.** Value crosses into the EVM intent graph (or vice-versa for edge destinations) and settles to the recipient, exactly as in a standard Trails flow.
+
+<Note>
+An edge-origin intent still designates an EVM address as the intent's refund owner, even though the user funds from a non-EVM wallet. This is an internal detail of how the intent is anchored; the funding and signing happen on the edge chain.
+</Note>
+
+## Addresses and tokens
+
+Edge chains use their ecosystem-native conventions rather than EVM ones:
+
+- **Addresses** follow the edge chain's own format (for example, base58 rather than `0x`-prefixed hex).
+- **Native and token identifiers** use the edge chain's native scheme. Trails resolves known edge tokens from a built-in catalog rather than the EVM supported-tokens API.
+
+The SDK's `Token` and `Chain` types are chain-agnostic, so the same shapes carry both EVM and edge data. See [Tokens & Chains](/sdk/tokens-and-chains) for the SDK-side utilities.
+
+## Adding new alternative VMs
+
+The edge-rail model is designed to grow without changing integration code:
+
+- New edge chains appear in the query results and quote paths as their rails go live.
+- Each ecosystem ships its own wallet adapter for edge-origin signing — see [Adapters](/sdk/adapters/overview).
+- The per-hook support matrix in [Hooks → Edge chains](/sdk/hooks#edge-chains) is organized by capability, not by chain, so it applies to any edge chain.
+
+<Note>
+Need an alternative VM that isn't listed yet? [Contact us](https://t.me/build_with_trails) to request it.
+</Note>

--- a/architecture/edge-alt-vms.mdx
+++ b/architecture/edge-alt-vms.mdx
@@ -25,7 +25,7 @@ Edge support is asymmetric. What an integration needs depends on whether the edg
 | **What the user signs** | A transaction in their edge-chain wallet | Nothing on the edge chain |
 | **Recipient** | — | An edge-chain address |
 
-**Why origin needs an adapter.** A non-EVM chain uses its own signing scheme and transaction format — an EVM `walletClient` (viem) cannot produce a valid signature for it. Executing an edge-origin transaction therefore requires an ecosystem-native signer, supplied by the edge wallet adapter registered on `TrailsProvider`. Without it, edge-origin execution is unavailable and the SDK surfaces an explicit error.
+**Why origin needs an adapter.** A non-EVM chain uses its own signing scheme and transaction format — an EVM `walletClient` (viem) cannot produce a valid signature for it. Executing an edge-origin transaction therefore requires an ecosystem-native signer, supplied by the edge wallet adapter registered on `TrailsProvider` (currently the [Solana adapter](/sdk/adapters/solana)). Without it, edge-origin execution is unavailable and the SDK surfaces an explicit error.
 
 **Why destination does not.** When an edge chain is only the destination, the user still signs a single EVM origin transaction as usual. Trails routes the value across the edge rail and settles to the edge-chain recipient address — no edge wallet or adapter is involved on the user's side.
 
@@ -55,7 +55,7 @@ The SDK's `Token` and `Chain` types are chain-agnostic, so the same shapes carry
 The edge-rail model is designed to grow without changing integration code:
 
 - New edge chains appear in the query results and quote paths as their rails go live.
-- Each ecosystem ships its own wallet adapter for edge-origin signing — see [Adapters](/sdk/adapters/overview).
+- Each ecosystem ships its own wallet adapter for edge-origin signing — see [Adapters](/sdk/adapters/overview) (e.g. the [Solana adapter](/sdk/adapters/solana)).
 - The per-hook support matrix in [Hooks → Edge chains](/sdk/hooks#edge-chains) is organized by capability, not by chain, so it applies to any edge chain.
 
 <Note>

--- a/docs.json
+++ b/docs.json
@@ -67,6 +67,7 @@
               "architecture/pricing-fees",
               "architecture/alt-fee-tokens",
               "architecture/unified-liquidity",
+              "architecture/edge-alt-vms",
               "architecture/smart-contracts"
             ]
           },

--- a/resources/supported-chains.mdx
+++ b/resources/supported-chains.mdx
@@ -34,6 +34,15 @@ Trails supports the following mainnet chains with full cross-chain routing capab
 Berachain, Sonic, Monad, and Somnia are newly integrated chains shipping with v1.5. Route coverage and supported token pairs will expand over time.
 </Note>
 
+## Edge Chains
+
+Trails supports **edge chains** — non-EVM ecosystems reached through edge rails that settle into any supported EVM chain and back. Every alternative-VM chain is an edge chain. These chains use their ecosystem-native chain IDs and address formats.
+
+| Chain | VM | Chain ID | Native Token | Status |
+|-------|-----|----------|--------------|--------|
+| Solana | SVM | 101 | SOL | ✅ Supported |
+| Tron | TVM | — | TRX | 🚧 Coming soon (TBA) |
+
 ## Stablecoin Details
 
 ### USDC Availability
@@ -49,6 +58,7 @@ USDC is available on most major chains. Chains with CCTP support enable native U
 | Polygon | `0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359` | ✓ |
 | Avalanche | `0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E` | ✓ |
 | BNB Chain | `0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d` | - |
+| Solana | `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` | - |
 
 ### USDT Availability
 
@@ -60,6 +70,11 @@ USDC is available on most major chains. Chains with CCTP support enable native U
 | Polygon | `0xc2132D05D31c914a87C6611C10748AEb04B58e8F` |
 | Avalanche | `0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7` |
 | BNB Chain | `0x55d398326f99059fF775485246999027B3197955` |
+| Solana | `Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB` |
+
+<Note>
+Addresses on **Solana** are base58 SPL mint addresses, not EVM contract addresses. Solana routes via edge rails rather than CCTP.
+</Note>
 
 ## Supported Bridges and Liquidity
 

--- a/sdk/changelog.mdx
+++ b/sdk/changelog.mdx
@@ -6,6 +6,10 @@ description: "Release notes and migration notes for the 0xtrails SDK"
 Track SDK releases, migration guidance, and notable changes.
 
 <CardGroup cols={1}>
+  <Card title="0xtrails@0.17.0" icon="tag" href="/sdk/changelog/0xtrails-0.17.0">
+    July 21, 2026 · Solana support arrives — pay from and to Solana via edge rails with the new `@0xtrails/svm` adapter, plus gasless
+    transactions and new bridge providers.
+  </Card>
   <Card title="0xtrails@0.16.0" icon="tag" href="/sdk/changelog/0xtrails-0.16.0">
     May 21, 2026 · wagmi is now opt-in, fund flows support exact-output quoting, and quote handling supports passthrough quote, fee, and approval data.
   </Card>

--- a/sdk/changelog/0xtrails-0.17.0.mdx
+++ b/sdk/changelog/0xtrails-0.17.0.mdx
@@ -1,0 +1,146 @@
+---
+title: "0xtrails@0.17.0"
+description: "Release notes for the 0xtrails SDK v0.17.0 — introducing Solana (SVM) support"
+---
+
+_Released July 21, 2026_
+
+This release covers changes after `0xtrails@0.16.0` through `0xtrails@0.17.0`.
+
+The headline of this release is **Solana support** — the first time Trails routes to and from a non-EVM chain. This is delivered through Trails' new
+[edge rail](/architecture/edge-alt-vms) model, so Solana slots into the same intent lifecycle, hooks, and widget you already use.
+
+## Highlights
+
+- **Solana (SVM) support** — pay *from* Solana (Solana → EVM) and *to* Solana (EVM → Solana), powered by [edge rails](/architecture/edge-alt-vms).
+- **New package `@0xtrails/svm`** exporting `svmAdapter`, with built-in [Wallet Standard](https://github.com/wallet-standard/wallet-standard)
+auto-detection (Phantom, Solflare, Backpack, …).
+- **Unified EVM + Solana wallet connection** — one tabbed connect flow, with Solana wallets shown in the connected-wallets list and disconnect controls.
+- **Gasless transactions** in `useTrailsSendTransaction`.
+- **Recover-funds screen** for failed intents in transaction history.
+- New bridge route providers: **LayerZero Transfer (`LZ_TRANSFER`)**, **OIF**, and **Hyperlane**.
+- Migrated to [Solana Kit (`@solana/kit`)](https://github.com/anza-xyz/kit) internally and moved the SDK build to `tsdown` for faster builds and better tree-shaking.
+
+## Introducing Solana
+
+Solana is Trails' first **edge chain** — a non-EVM ecosystem reached through an [edge rail](/architecture/edge-alt-vms) rather than a separate protocol. The intent
+is still anchored in the EVM orchestration described in [How Trails Works](/architecture/how-it-works); the Solana leg sits at the *edge* of the flow, as either
+the origin the user funds from or the destination funds settle into.
+
+### What you can build
+
+| Direction | Wallet the user needs | SDK adapter |
+|--|--|--|
+| **Solana → EVM** (edge as origin) | A Solana wallet | Required — [`svmAdapter`](/sdk/adapters/solana) |
+| **EVM → Solana** (edge as destination) | A standard EVM wallet | Not required — just an SVM recipient address |
+
+Paying **from** Solana requires an ecosystem-native signer, because a viem `walletClient` can't sign a Solana transaction — supply it with `svmAdapter`.
+Paying **to** Solana works with a plain EVM wallet: the user signs one EVM origin transaction and Trails settles to the Solana recipient. See
+[Edge & Alternative VMs](/architecture/edge-alt-vms#origin-vs-destination) for the full model.
+
+### Add it to your widget
+
+`svmAdapter` from `@0xtrails/svm` registers the SVM edge plugin and provides the Solana wallet context. Auto-detection needs no app-level Solana provider:
+
+```tsx
+import { Fund } from '0xtrails'
+import { svmAdapter } from '@0xtrails/svm'
+
+<Fund
+  to={{ recipient: '0x...', token: 'USDC', chain: 'polygon', amount: '100' }}
+  apiKey="YOUR_API_KEY"
+  adapters={[
+    // Use your own private RPC for production
+    svmAdapter({ rpcUrls: ['https://api.mainnet-beta.solana.com'] }),
+  ]}
+/>
+```
+
+EVM and Solana adapters compose — pass both and both wallet families work in the same widget. The adapter also accepts a bring-your-own-wallet
+handle for the modern `@solana/react-hooks` stack or the legacy `@solana/wallet-adapter-react` stack. See the [Solana Adapter](/sdk/adapters/solana)
+guide for every integration style and the [Adapters overview](/sdk/adapters/overview) for how adapters compose.
+
+### Hooks are edge-aware
+
+Solana is supported at the **quote and execution layer**. Pass an edge chain (by name or its ecosystem-native chain ID, e.g. `101` for Solana) anywhere
+these hooks accept an EVM chain — `useQuote`, `useTrailsSendTransaction`, `useIntentTransactionHistory`, `getChainInfo`, and `useTokenInfo`. The chain/token *list* and
+*balance* utilities remain EVM-only. See [Hooks → Edge chains](/sdk/hooks#edge-chains) for the exact per-hook support matrix,
+and [Tokens & Chains](/sdk/tokens-and-chains#edge-chains) for the chain-agnostic `Chain`/`Token` shapes.
+
+### Under the hood
+
+Edge routes are quoted through a new API path, [`QuoteIntentEdge`](/api-reference/endpoints/quote-intent-edge), which pairs the standard `QuoteIntentRequest`
+with an `edge` request describing the rail (`SOLANA`), mode (`ORIGIN` / `DESTINATION`), and Solana-side token/address. If you use `useQuote` or the widget
+you don't call this directly — the SDK selects the edge path automatically when a route touches Solana. It's available for direct API integrations that need it.
+
+For the current list of edge chains (Solana today, Tron TBA) and their tokens, see [Supported Chains → Edge Chains](/resources/supported-chains#edge-chains).
+
+## New Package
+
+- Add [`@0xtrails/svm`](/sdk/adapters/solana), exporting `svmAdapter` for Solana (SVM) wallet support. Install it alongside `0xtrails`:
+
+  ```bash
+  pnpm add 0xtrails @0xtrails/svm
+  ```
+
+## Features
+
+### Solana / SVM
+
+- Add Solana as a payment **origin** (Solana → EVM) and **destination** (EVM → Solana) via the edge relay.
+- Add Solana wallet support with a unified connection flow for EVM and SVM wallets.
+- Auto-detect Solana Wallet Standard providers (Phantom, Solflare, Backpack, …).
+- Add Solana wallets to the Settings connected-wallets list with disconnect controls.
+
+### Quotes, Intents, and Transactions
+
+- Add gasless transaction support to `useTrailsSendTransaction`.
+- Add a recover-funds screen for failed intents in transaction history.
+- Add fund **exact-output** mode for precise destination amounts.
+- Add **LayerZero Transfer (`LZ_TRANSFER`)** and **OIF** bridge provider options.
+- Add **Hyperlane** bridge provider scenarios.
+- Show swap and bridge route providers in transaction details and history.
+
+### Widget and Checkout UX
+
+- Add a recipient picker with a pulsating prompt for clearer guidance.
+- Add a refresh button to the token selectors.
+- Add a theme creator tool in the demo for customizing widget appearance.
+
+## Improvements
+
+- Make **wagmi 3** the default for the built-in EVM wallet integration.
+- Migrate to [Solana Kit (`@solana/kit`)](https://github.com/anza-xyz/kit) for improved Solana integration.
+- Migrate the SDK build to `tsdown` for faster builds and better tree-shaking.
+- Unify the wallet connection flow with a tabbed EVM / Solana interface, and hide the SVM tab when Solana edge is not enabled by the API.
+- Auto-sync the selected origin/destination chain with the connected wallet and recipient address types.
+- Require an EVM wallet connection before allowing Solana wallet connections.
+- Centralize chain resolution, wallet icons, and payment-source mapping across the widget.
+- Improve quote input error detection for edge amount limits.
+- Improve widget loading and error states for exchange integrations.
+- Support object params for the sufficient-balance hooks.
+- Hide the approval prompt for embedded wallets, and hide the "Add wallet" option from the fund-methods screen via prop.
+
+## Fixes
+
+- Fix Solana destination recipient sync and validation.
+- Fix wallet cancellations on Solana being treated as retryable errors.
+- Fix duplicate Solana destination fill state in the transaction timeline.
+- Fix SOL price fetching in Pay mode.
+- Fix Solana appearing in the Swap destination chain filter without the SVM plugin.
+- Fix multi-wallet connection regressions for EVM and SVM, and multiple accounts from the same wallet provider not displaying correctly.
+- Fix transaction states on finished intents and edge receipt sync.
+- Fix same-chain / same-token transfers with calldata for exact input and output.
+- Fix salt-based EIP-712 domains for Polygon USDT permit signatures.
+- Fix EVM signer address resolution when the wallet client is unset.
+- Reject destination calls with empty calldata.
+- Fix `waitIntentReceipt` abort on widget close or navigation.
+- Fix the token selector showing all wallet tokens when API search is enabled.
+- Fix embedded wallet fee-confirmation hangs and the connect-wallet close button behavior.
+- Fix the clipboard copy fallback for older browsers.
+
+## Breaking Changes
+
+- **Drop v1 intent protocol support** — only v2 intents are supported. If you're still on v1, follow the [v1.5 migration guide](/resources/v1-5-migration).
+- **Remove the native Coinbase and Safe wallet connectors** — use WalletConnect instead.
+- **Remove the `react-motion` dependency** from widget animations.

--- a/sdk/changelog/0xtrails-0.17.0.mdx
+++ b/sdk/changelog/0xtrails-0.17.0.mdx
@@ -5,8 +5,6 @@ description: "Release notes for the 0xtrails SDK v0.17.0 — introducing Solana 
 
 _Released July 21, 2026_
 
-This release covers changes after `0xtrails@0.16.0` through `0xtrails@0.17.0`.
-
 The headline of this release is **Solana support** — the first time Trails routes to and from a non-EVM chain. This is delivered through Trails' new
 [edge rail](/architecture/edge-alt-vms) model, so Solana slots into the same intent lifecycle, hooks, and widget you already use.
 
@@ -18,8 +16,7 @@ auto-detection (Phantom, Solflare, Backpack, …).
 - **Unified EVM + Solana wallet connection** — one tabbed connect flow, with Solana wallets shown in the connected-wallets list and disconnect controls.
 - **Gasless transactions** in `useTrailsSendTransaction`.
 - **Recover-funds screen** for failed intents in transaction history.
-- New bridge route providers: **LayerZero Transfer (`LZ_TRANSFER`)**, **OIF**, and **Hyperlane**.
-- Migrated to [Solana Kit (`@solana/kit`)](https://github.com/anza-xyz/kit) internally and moved the SDK build to `tsdown` for faster builds and better tree-shaking.
+- New bridge route providers: **Hyperlane**.
 
 ## Introducing Solana
 
@@ -97,7 +94,6 @@ For the current list of edge chains (Solana today, Tron TBA) and their tokens, s
 - Add gasless transaction support to `useTrailsSendTransaction`.
 - Add a recover-funds screen for failed intents in transaction history.
 - Add fund **exact-output** mode for precise destination amounts.
-- Add **LayerZero Transfer (`LZ_TRANSFER`)** and **OIF** bridge provider options.
 - Add **Hyperlane** bridge provider scenarios.
 - Show swap and bridge route providers in transaction details and history.
 
@@ -141,6 +137,7 @@ For the current list of edge chains (Solana today, Tron TBA) and their tokens, s
 
 ## Breaking Changes
 
-- **Drop v1 intent protocol support** — only v2 intents are supported. If you're still on v1, follow the [v1.5 migration guide](/resources/v1-5-migration).
+- **Drop v1 intent protocol support** — only v2 intents are supported. If you're still on v1, follow
+the [v1.5 migration guide](/resources/v1-5-migration).
 - **Remove the native Coinbase and Safe wallet connectors** — use WalletConnect instead.
 - **Remove the `react-motion` dependency** from widget animations.

--- a/sdk/hooks.mdx
+++ b/sdk/hooks.mdx
@@ -141,7 +141,7 @@ Edge chains (non-EVM / alternative VMs — see [Supported Chains](/resources/sup
 | `useIntentRecover` / `useIntentRecoverWithAddress` | EVM only |
 
 <Note>
-**Execution model.** Paying *from* an edge chain (edge as origin) requires the matching edge wallet adapter registered on `TrailsProvider` plus a connected edge wallet — a viem `walletClient` cannot sign an edge-chain transaction. See [Adapters](/sdk/adapters/overview). Paying *to* an edge chain (edge as destination) works with a standard EVM wallet and an edge recipient address — no adapter needed.
+**Execution model.** Paying *from* an edge chain (edge as origin) requires the matching edge wallet adapter registered on `TrailsProvider` plus a connected edge wallet — a viem `walletClient` cannot sign an edge-chain transaction. See [Adapters](/sdk/adapters/overview) (currently the [Solana adapter](/sdk/adapters/solana)). Paying *to* an edge chain (edge as destination) works with a standard EVM wallet and an edge recipient address — no adapter needed.
 </Note>
 
 ## Chains

--- a/sdk/hooks.mdx
+++ b/sdk/hooks.mdx
@@ -121,6 +121,29 @@ Added in [`0xtrails@0.16.0`](/sdk/changelog/0xtrails-0.16.0). Adapters are a **w
 
 Hooks-based integrations do not use adapters. Supply wallet state directly to hooks such as `useQuote` and `useTrailsSendTransaction` via `walletClient` and `address` from your own wallet stack (wagmi, viem, ethers, etc.).
 
+## Edge chains
+
+Edge chains (non-EVM / alternative VMs — see [Supported Chains](/resources/supported-chains)) are supported at the **quote and execution layer**, not uniformly across every hook. Chain-family handling is transparent to the hooks that support it — pass an edge chain via `ChainIdentifier` (name or chain ID) the same way you pass an EVM chain.
+
+| Hook / utility | Edge chains |
+|----------------|-------------|
+| `useQuote` (`from.chain` / `to.chain`) | ✅ Supported |
+| `useTrailsSendTransaction` | ✅ Supported |
+| `useIntentTransactionHistory` | ✅ Supported (pass the edge address) |
+| `getChainInfo`, `useTokenInfo` | ✅ Supported |
+| `useSupportedChains` / `getSupportedChains` | EVM only |
+| `useSupportedTokens` / `useTokenList` / `getSupportedTokens` | EVM only |
+| `getAllChains`, `useTokenAddress` | EVM only |
+| Balance hooks (`useTokenBalances`, `useAccountTotalBalanceUsd`, `useHasSufficientBalance*`) | EVM only |
+| `usePublicClient` / `usePublicClientGetter` | EVM only (edge chains use ecosystem-native RPC, not viem) |
+| `useAccountTransactionHistory` / `getAccountTransactionHistory` | EVM only |
+| Earn hooks (`useEarnMarkets`, `useEarnProviders`, `useEarnBalances`) | EVM only |
+| `useIntentRecover` / `useIntentRecoverWithAddress` | EVM only |
+
+<Note>
+**Execution model.** Paying *from* an edge chain (edge as origin) requires the matching edge wallet adapter registered on `TrailsProvider` plus a connected edge wallet — a viem `walletClient` cannot sign an edge-chain transaction. See [Adapters](/sdk/adapters/overview). Paying *to* an edge chain (edge as destination) works with a standard EVM wallet and an edge recipient address — no adapter needed.
+</Note>
+
 ## Chains
 
 ```ts

--- a/sdk/tokens-and-chains.mdx
+++ b/sdk/tokens-and-chains.mdx
@@ -7,6 +7,16 @@ description: "Working with supported tokens and chains in the Trails SDK"
 
 The Trails SDK provides utilities to query supported chains and tokens across the network. These functions help you build dynamic UIs that adapt to available options.
 
+## Edge Chains
+
+Trails extends beyond EVM networks to **edge chains** — non-EVM ecosystems reached through *edge rails*. All alternative-VM chains are edge chains: funding from an edge-chain wallet settles into any supported EVM chain, and back, with Trails handling the cross-ecosystem routing.
+
+Edge chains are handled at the quote and execution layer — `useQuote` and `useTrailsSendTransaction` accept an edge chain anywhere they accept an EVM chain, and the `Chain` and `Token` types are chain-agnostic. Edge chains use their ecosystem-native chain IDs and address formats rather than EVM conventions. Not every hook is edge-aware: the chain/token list and balance utilities below are EVM-only. See [Hooks → Edge chains](/sdk/hooks#edge-chains) for the exact per-hook support matrix and the edge execution model.
+
+<Note>
+For the current list of supported edge chains and their tokens, see [Supported Chains](/resources/supported-chains).
+</Note>
+
 ## Chain Utilities
 
 ```ts


### PR DESCRIPTION
## Summary

Documents Trails' edge-rail support for non-EVM / alternative VM chains (Solana supported today, Tron TBA). Written chain-agnostically so the SDK/architecture pages don't need updating as new edge chains land — chain specifics live only on the Supported Chains reference page.

## Changes

- **`architecture/edge-alt-vms.mdx`** (new) — "Edge & Alternative VMs" page covering the edge-rail model, the origin-vs-destination asymmetry (and why edge-origin needs a wallet adapter while destination doesn't), the execution flow, address/token conventions, and how new alternative VMs are added.
- **`sdk/hooks.mdx`** — new **Edge chains** section with a per-hook capability matrix (edge-aware vs EVM-only, verified against the `0xtrails` source) plus the edge execution-model note.
- **`sdk/tokens-and-chains.mdx`** — new **Edge chains** section deferring to the chains list and the hooks matrix.
- **`resources/supported-chains.mdx`** — **Edge Chains** table (Solana ✅, Tron 🚧 TBA) and the Solana USDC/USDT SPL mints folded into Stablecoin Details.
- **`docs.json`** — new architecture page added to nav.

## Notes

- The hooks matrix reflects that edge support is a **quote/execution-layer** capability, not uniform across every hook — list/balance/public-client/earn/recovery hooks remain EVM-only.
- Not addressed here: `architecture/how-it-works.mdx` still says non-EVM support is a future plan, which is now stale. Can fix in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)