### PR TITLE
docs: update sdk docs 2026-08-03

### DIFF
--- a/sdk/quote-providers.mdx
+++ b/sdk/quote-providers.mdx
@@ -23,6 +23,7 @@ Trails integrates with multiple liquidity sources and bridge providers to find t
 - **`WETH`**: Wrap/unwrap ETH ↔ WETH on the same chain
 - **`SOMNIA_EXCHANGE`**: Uses Somnia Exchange for swaps on Somnia
 - **`SOMNIA_SWAP`**: Uses Somnia Swap for swaps on Somnia
+- **`EVERLONG`**: Uses Everlong for same-chain swaps on Katana
 
 ## Configuration
 
@@ -182,6 +183,18 @@ Native swap providers on Somnia (chain id `5031`). Used for on-chain swaps withi
 ```tsx
 <Swap apiKey="YOUR_API_KEY" swapProvider="SOMNIA_EXCHANGE" />
 <Swap apiKey="YOUR_API_KEY" swapProvider="SOMNIA_SWAP" />
+```
+
+### Everlong
+
+Native swap provider on Katana (chain id `747474`). Used for same-chain swaps between Everlong-listed tokens.
+
+- Same-chain swaps only; not used for bridging
+- Exact-input (`tradeType: "EXACT_INPUT"`) only — exact-output is not supported
+- Requires explicit `swapProvider="EVERLONG"`; not currently selected by AUTO
+
+```tsx
+<Swap apiKey="YOUR_API_KEY" swapProvider="EVERLONG" />
 ```
 
 ## Best Practices


### PR DESCRIPTION
## What changed

- `sdk/quote-providers.mdx` — add `EVERLONG` to the "Available Providers" list and add a dedicated section under "Provider Details" describing it (same-chain swap on Katana, exact-input only, explicit selection only — not picked by `AUTO`).

## Source of truth

- 0xsequence/trails-api#1023 — "Everlong hotfix" cherry-picking #1015 into `release`, merged 2026-07-28.
- `lib/routes/everlong/everlong.go` on `release`:
  - `IsChainSupported`: `chainID == ChainIDKatana` — Katana (`747474`) only.
  - `checkCapabilitiesForRoute`: rejects cross-chain (`originChainID != destinationChainID` returns error) — same-chain only.
  - `operations` map: `RouteOperation_Swap: true`, `RouteOperation_SwapExactInput: true`, `RouteOperation_SwapExactOutput: false`.
- `lib/routes/routes.go` on `release`: `ExplicitOnlySwapRoutes: []string{"EVERLONG"}` — the routing solver's `ExplicitOnlySwapProvider` architecture excludes EVERLONG from `AUTO` candidate lists (see `TestBuildRouteCandidates_ExplicitOnlySwapRouteIgnoredInAuto` in `lib/intentmachine/routingsolver/route_preference_test.go`).

## Verification

- Grep confirms EVERLONG did not already appear anywhere under `trails-docs/` before this change.
- The added prose matches the pattern of the existing OIF / LZ_TRANSFER entries (explicit-only providers).

Generated by the Trails Docs weekly agent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxmfFuVZAcf1dtPe2X8skT)_