### PR TITLE
docs: update sdk docs 2026-08-10

### DIFF
--- a/overview/cross-chain-execution.mdx
+++ b/overview/cross-chain-execution.mdx
@@ -64,7 +64,7 @@ Deposit into an Aave lending pool on Arbitrum using tokens from any chain:
 
 ```tsx
 import { Fund } from '0xtrails/widget'
-import { TRAILS_ROUTER_PLACEHOLDER_AMOUNT } from '0xtrails'
+import { TRAILS_HYDRATE_PLACEHOLDER_AMOUNT } from '0xtrails'
 import { encodeFunctionData } from 'viem'
 
 const supplyCalldata = encodeFunctionData({
@@ -83,7 +83,7 @@ const supplyCalldata = encodeFunctionData({
   functionName: 'supply',
   args: [
     '0xUSDCAddress',
-    TRAILS_ROUTER_PLACEHOLDER_AMOUNT, // Replaced with actual amount at execution
+    TRAILS_HYDRATE_PLACEHOLDER_AMOUNT, // Replaced with actual amount at execution
     '0xUserAddress',
     0,
   ],
@@ -111,7 +111,7 @@ When the function parameters are known in advance:
 - Any function where amount isn't a parameter
 
 ### Dynamic Calldata
-When the amount needs to be determined at execution time, use `TRAILS_ROUTER_PLACEHOLDER_AMOUNT`:
+When the amount needs to be determined at execution time, use `TRAILS_HYDRATE_PLACEHOLDER_AMOUNT`:
 - ERC-4626 vault deposits
 - Lending protocol supplies
 - Any function with an `amount` parameter that should match bridged funds

--- a/sdk/hooks.mdx
+++ b/sdk/hooks.mdx
@@ -921,10 +921,10 @@ const { data: providers } = useMeldServiceProviders({
 ## Constants
 
 ```ts
-import { TRAILS_ROUTER_PLACEHOLDER_AMOUNT } from '0xtrails'
+import { TRAILS_HYDRATE_PLACEHOLDER_AMOUNT } from '0xtrails'
 ```
 
-### TRAILS_ROUTER_PLACEHOLDER_AMOUNT
+### TRAILS_HYDRATE_PLACEHOLDER_AMOUNT
 
 This constant provides a placeholder value for amounts when encoding calldata in fund mode. It's used to replace dynamic output amounts during contract execution.
 
@@ -934,13 +934,13 @@ This constant provides a placeholder value for amounts when encoding calldata in
 ```tsx
 import { Fund } from '0xtrails/widget'
 import { encodeFunctionData } from 'viem'
-import { TRAILS_ROUTER_PLACEHOLDER_AMOUNT } from '0xtrails'
+import { TRAILS_HYDRATE_PLACEHOLDER_AMOUNT } from '0xtrails'
 
 export const Example = () => {
     const calldata = encodeFunctionData({
         abi: stakingABI,
         functionName: 'stake',
-        args: [TRAILS_ROUTER_PLACEHOLDER_AMOUNT] // Will be replaced with actual amount
+        args: [TRAILS_HYDRATE_PLACEHOLDER_AMOUNT] // Will be replaced with actual amount
     })
 
     return (
@@ -1707,7 +1707,6 @@ These are advanced functions for direct intent management. Most developers shoul
 
 ```ts
 import {
-  calculateOriginAndDestinationIntentAddresses,
   commitIntent,
   sendOriginTransaction,
 } from '0xtrails'
@@ -1723,30 +1722,11 @@ type OriginCallParams = {
   chainId: number
 }
 
-type RouteProvider = 'AUTO' | 'CCTP' | 'RELAY' | 'SUSHI' | 'ZEROX'
-
 type TrailsFee = {
   amount: bigint
   amountUsd: number
   token: Token
 }
-```
-
-### calculateOriginAndDestinationIntentAddresses
-
-Calculates both origin and destination intent addresses.
-
-**Signature**:
-```ts
-function calculateOriginAndDestinationIntentAddresses(
-  params: IntentParams
-): Promise<{ originAddress: string; destinationAddress: string }>
-```
-
-**Usage**:
-```ts
-const { originAddress, destinationAddress } =
-  await calculateOriginAndDestinationIntentAddresses(params)
 ```
 
 ### commitIntent

--- a/sdk/modes/earn.mdx
+++ b/sdk/modes/earn.mdx
@@ -153,11 +153,11 @@ const supplyCalldata = encodeFunctionData({
 
 ### ERC-4626 vault with dynamic amount
 
-Use `TRAILS_ROUTER_PLACEHOLDER_AMOUNT` when the deposit amount is a parameter and the user selects it:
+Use `TRAILS_HYDRATE_PLACEHOLDER_AMOUNT` when the deposit amount is a parameter and the user selects it:
 
 ```tsx
 import { Earn } from '0xtrails/widget'
-import { TRAILS_ROUTER_PLACEHOLDER_AMOUNT } from '0xtrails'
+import { TRAILS_HYDRATE_PLACEHOLDER_AMOUNT } from '0xtrails'
 import { encodeFunctionData } from 'viem'
 
 const depositCalldata = encodeFunctionData({
@@ -172,7 +172,7 @@ const depositCalldata = encodeFunctionData({
     outputs: [{ name: 'shares', type: 'uint256' }],
   }],
   functionName: 'deposit',
-  args: [TRAILS_ROUTER_PLACEHOLDER_AMOUNT, '0xUserAddress'],
+  args: [TRAILS_HYDRATE_PLACEHOLDER_AMOUNT, '0xUserAddress'],
 })
 
 <Earn
@@ -189,7 +189,7 @@ const depositCalldata = encodeFunctionData({
 ```
 
 <Note>
-Use `TRAILS_ROUTER_PLACEHOLDER_AMOUNT` when:
+Use `TRAILS_HYDRATE_PLACEHOLDER_AMOUNT` when:
 - Deposit amount is a function parameter
 - User selects the deposit amount
 - Amount needs to reflect post-swap/bridge output
@@ -235,13 +235,13 @@ Use `useEarnMarkets` to discover available market IDs. See [Markets and Provider
 
 ## Calldata reference
 
-### When to use `TRAILS_ROUTER_PLACEHOLDER_AMOUNT`
+### When to use `TRAILS_HYDRATE_PLACEHOLDER_AMOUNT`
 
 ```tsx
 // Correct — dynamic amount in calldata
 encodeFunctionData({
   functionName: 'deposit',
-  args: [TRAILS_ROUTER_PLACEHOLDER_AMOUNT, userAddress],
+  args: [TRAILS_HYDRATE_PLACEHOLDER_AMOUNT, userAddress],
 })
 
 // Correct — function reads balance directly, no placeholder needed
@@ -251,7 +251,7 @@ encodeFunctionData({
 })
 ```
 
-`TRAILS_ROUTER_PLACEHOLDER_AMOUNT` is `uint256.max` internally. Trails replaces it with the actual output amount at execution time.
+`TRAILS_HYDRATE_PLACEHOLDER_AMOUNT` is `uint256.max` internally. Trails replaces it with the actual output amount at execution time.
 
 ## See also
 

--- a/sdk/modes/fund.mdx
+++ b/sdk/modes/fund.mdx
@@ -252,11 +252,11 @@ The widget shows a pending state while the exchange processes the withdrawal. Se
 
 ### Protocol deposit with dynamic calldata
 
-For ERC-4626 vaults and staking contracts where the deposit amount is a function parameter, use `TRAILS_ROUTER_PLACEHOLDER_AMOUNT`. Trails replaces it with the actual bridged/swapped output at execution time.
+For ERC-4626 vaults and staking contracts where the deposit amount is a function parameter, use `TRAILS_HYDRATE_PLACEHOLDER_AMOUNT`. Trails replaces it with the actual bridged/swapped output at execution time.
 
 ```tsx
 import { Fund } from '0xtrails/widget'
-import { TRAILS_ROUTER_PLACEHOLDER_AMOUNT } from '0xtrails'
+import { TRAILS_HYDRATE_PLACEHOLDER_AMOUNT } from '0xtrails'
 import { encodeFunctionData } from 'viem'
 
 const depositCalldata = encodeFunctionData({
@@ -271,7 +271,7 @@ const depositCalldata = encodeFunctionData({
     outputs: [{ name: 'shares', type: 'uint256' }],
   }],
   functionName: 'deposit',
-  args: [TRAILS_ROUTER_PLACEHOLDER_AMOUNT, '0xReceiverAddress'],
+  args: [TRAILS_HYDRATE_PLACEHOLDER_AMOUNT, '0xReceiverAddress'],
 })
 
 <Fund
@@ -287,7 +287,7 @@ const depositCalldata = encodeFunctionData({
 ```
 
 <Note>
-Use `TRAILS_ROUTER_PLACEHOLDER_AMOUNT` when the deposit amount is a function parameter and the user selects the amount. Do not use it for functions that read balance internally (e.g. `depositAll()`).
+Use `TRAILS_HYDRATE_PLACEHOLDER_AMOUNT` when the deposit amount is a function parameter and the user selects the amount. Do not use it for functions that read balance internally (e.g. `depositAll()`).
 </Note>
 
 ## See also

--- a/use-cases/fund.mdx
+++ b/use-cases/fund.mdx
@@ -116,12 +116,12 @@ export function YearnDepositButton({ recipient }: { recipient: `0x${string}` }) 
 
 ### Depositing into a custom contract
 
-For protocols not covered by composable actions, use `TRAILS_ROUTER_PLACEHOLDER_AMOUNT` in `to.calldata`:
+For protocols not covered by composable actions, use `TRAILS_HYDRATE_PLACEHOLDER_AMOUNT` in `to.calldata`:
 
 <CodeGroup>
 ```tsx CustomVaultDeposit.tsx
 import { Fund } from '0xtrails/widget'
-import { TRAILS_ROUTER_PLACEHOLDER_AMOUNT } from '0xtrails'
+import { TRAILS_HYDRATE_PLACEHOLDER_AMOUNT } from '0xtrails'
 import { encodeFunctionData } from 'viem'
 import { customVaultABI } from './abi.ts'
 
@@ -132,7 +132,7 @@ export const CustomVaultDeposit = () => {
     abi: customVaultABI,
     functionName: 'deposit',
     args: [
-      TRAILS_ROUTER_PLACEHOLDER_AMOUNT, // replaced with actual output at execution
+      TRAILS_HYDRATE_PLACEHOLDER_AMOUNT, // replaced with actual output at execution
       "0x...",                          // receiver address
     ],
   })


### PR DESCRIPTION
## What changed

- `sdk/hooks.mdx`
  - Rename `TRAILS_ROUTER_PLACEHOLDER_AMOUNT` → `TRAILS_HYDRATE_PLACEHOLDER_AMOUNT` in the Constants section.
  - Remove the `calculateOriginAndDestinationIntentAddresses` section from *Advanced: Intent Functions* — this v1-only helper is no longer exported by `0xtrails`.
  - Remove the hand-written `RouteProvider = 'AUTO' | 'CCTP' | 'RELAY' | 'SUSHI' | 'ZEROX'` type example. It was missing every provider added since v0.15 (`LIFI`, `GASZIP`, `LZ_OFT`, `LZ_TRANSFER`, `OIF`, `HYPERLANE`, `WETH`, `SOMNIA_EXCHANGE`, `SOMNIA_SWAP`, `EVERLONG`). The OpenAPI spec is the source of truth for enum members.
- `sdk/modes/fund.mdx`, `sdk/modes/earn.mdx`, `use-cases/fund.mdx`, `overview/cross-chain-execution.mdx`
  - Rename `TRAILS_ROUTER_PLACEHOLDER_AMOUNT` → `TRAILS_HYDRATE_PLACEHOLDER_AMOUNT` in code examples and prose.

## Source of truth

- `TRAILS_ROUTER_PLACEHOLDER_AMOUNT`, `calculateOriginAndDestinationIntentAddresses`, `getIntentConfigurationFromCalls`, and `TRAILS_ROUTER_ADDRESS` were removed from the `0xtrails` public exports in [0xsequence/trails#1136 "refactor: drop v1 intent protocol support"](https://github.com/0xsequence/trails/pull/1136), which shipped in [0xtrails v0.17.0](https://github.com/0xsequence/trails/releases/tag/0xtrails%400.17.0) (2026-07-21).
  - Diff of `packages/0xtrails/src/index.ts`: `TRAILS_ROUTER_PLACEHOLDER_AMOUNT` line removed from the `./placeholder.js` re-export block; the surviving export is `TRAILS_HYDRATE_PLACEHOLDER_AMOUNT`.
  - `packages/0xtrails/src/placeholder.ts` still exports `TRAILS_HYDRATE_PLACEHOLDER_AMOUNT` (unchanged sentinel: `0xfcbc96b9628c6a4da70c90b9e80f5f4ef82922d86bd4cb54db481ae22ed79c53n`).
- The 0.17.0 changelog page (`sdk/changelog/0xtrails-0.17.0.mdx`) already notes the v1 protocol drop and links to the [v1.5 migration guide](https://docs.trails.build/resources/v1-5-migration); this PR brings the rest of the docs into line with the new export names.
- Full RouteProvider enum members live in `api-reference/trails-api.gen.yaml` (a separate PR syncs this to the current release spec, adding `EVERLONG`).

## Verification

- `grep -rn "TRAILS_ROUTER_PLACEHOLDER_AMOUNT\|calculateOriginAndDestinationIntentAddresses\|getIntentConfigurationFromCalls\|TRAILS_ROUTER_ADDRESS" .` in `trails-docs` returns no matches after this PR.
- `grep -n "TRAILS_HYDRATE_PLACEHOLDER_AMOUNT\|TRAILS_ROUTER" packages/0xtrails/src/index.ts` in `0xsequence/trails@production` confirms `TRAILS_HYDRATE_PLACEHOLDER_AMOUNT` is exported and `TRAILS_ROUTER_*` is not.
- Every code snippet that previously imported `TRAILS_ROUTER_PLACEHOLDER_AMOUNT` still compiles by swapping in the surviving alias — sentinel value is unchanged.

Generated by the Trails Docs weekly agent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SN6twW1QNW1CmqWF6hHeuY)_